### PR TITLE
Update dependencies and fix sender handling on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arraydeque"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,9 +831,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "ssss"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2df3059527cd9e4d9ad525ded960a59105faa2f5252d218722075483711b2e"
+checksum = "193be117bf0ecebab1a073905485c42a58a821014b418f880a0bf2f1574c4311"
 dependencies = [
  "anyhow",
  "bon",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber-init"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b5bb9062390c3f3626a8ab90b14a384bce2c5b7281d166d4d295a6c281732e"
+checksum = "c5738faaf85e4548d3575f2763d8a84f4554ca9034206b38c2f88dbc2452cf86"
 dependencies = [
  "anyhow",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fnv"
@@ -1677,11 +1677,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.7.2"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2529c31017402be841eb45892278a6c21a000c0a17643af326c73a73f83f0fb"
+checksum = "f44aa969f86ffb99e5c2d51f393ec9ed6e9fe2f47b609c917b0071f129854d29"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.7.2"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82020dadcb845a345591863adb65d74fa8dc5c18a0b6d408470e13b7adc7005"
+checksum = "e1e78cd86b6a6515d87392332fd63c4950ed3e50eab54275259a5f59f3666f90"
 dependencies = [
  "darling",
  "ident_case",
@@ -886,11 +886,10 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1069,9 +1068,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1079,15 +1078,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.3",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1268,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.9.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -2264,6 +2264,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fnv"
@@ -832,9 +832,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -1506,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
  "serde_core",
 ]
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
  "serde_core",
  "serde_spanned",
@@ -1759,18 +1759,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -248,9 +248,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fnv"
@@ -1098,20 +1098,19 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pest"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
+checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
 dependencies = [
  "memchr",
- "thiserror 2.0.17",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663"
+checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1119,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f"
+checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1132,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420"
+checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
  "aws-lc-sys",
  "untrusted",
@@ -118,15 +118,16 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+checksum = "ee74396bee4da70c2e27cf94762714c911725efe69d9e2672f998512a67a4ce4"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "libloading",
 ]
 
 [[package]]
@@ -346,9 +347,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "config"
-version = "0.15.16"
+version = "0.15.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef036f0ecf99baef11555578630e2cca559909b4c50822dbba828c252d21c49"
+checksum = "680d3ac2fe066c43300ec831c978871e50113a708d58ab13d231bd92deca5adb"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -837,12 +838,12 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.3",
- "windows-link 0.2.0",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1422,6 +1423,7 @@ dependencies = [
  "interprocess",
  "libsalus",
  "redb",
+ "regex",
  "rustversion",
  "serde",
  "thiserror 2.0.16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1426,7 +1426,7 @@ dependencies = [
  "regex",
  "rustversion",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1608,7 +1608,7 @@ dependencies = [
  "rand",
  "rustversion",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1639,11 +1639,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44aa969f86ffb99e5c2d51f393ec9ed6e9fe2f47b609c917b0071f129854d29"
+checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e78cd86b6a6515d87392332fd63c4950ed3e50eab54275259a5f59f3666f90"
+checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
 dependencies = [
  "darling",
  "ident_case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.3",
@@ -142,7 +142,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -248,9 +248,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -630,7 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.3",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1260,9 +1260,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redb"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb1bfd2a09cb3c362dd10ea63427315cf3c79a84feb279394509981c4a3a91c"
+checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
 dependencies = [
  "libc",
 ]
@@ -1375,7 +1375,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1453,9 +1453,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1475,18 +1475,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,12 +1981,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
@@ -2024,16 +2018,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -2069,11 +2063,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,12 +837,12 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if 1.0.3",
- "windows-targets 0.53.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1451,9 +1451,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1473,18 +1473,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -1289,13 +1289,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
+ "regex-automata 0.4.11",
  "regex-syntax 0.8.6",
 ]
 
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee74396bee4da70c2e27cf94762714c911725efe69d9e2672f998512a67a4ce4"
+checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.3",
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2016,14 +2016,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.4",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -2061,19 +2061,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.4"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2090,9 +2090,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2108,9 +2108,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2126,9 +2126,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2138,9 +2138,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2156,9 +2156,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2174,9 +2174,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2192,9 +2192,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2210,9 +2210,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,9 +1453,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1475,18 +1475,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
 dependencies = [
  "bindgen",
  "cc",
@@ -347,9 +347,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "config"
-version = "0.15.17"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680d3ac2fe066c43300ec831c978871e50113a708d58ab13d231bd92deca5adb"
+checksum = "180e549344080374f9b32ed41bf3b6b57885ff6a289367b3dbc10eea8acc1918"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,9 +1860,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redb"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fefa3e5ff4a369819c3d6df4195873d6f9abad109f13c0d505dbe119cfabb10"
+checksum = "afb1bfd2a09cb3c362dd10ea63427315cf3c79a84feb279394509981c4a3a91c"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,14 +1287,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.11",
- "regex-syntax 0.8.6",
+ "regex-automata 0.4.12",
+ "regex-syntax 0.8.7",
 ]
 
 [[package]]
@@ -1308,13 +1308,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax 0.8.7",
 ]
 
 [[package]]
@@ -1325,9 +1325,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "ron"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber-init"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a4d66f071a77f1d043dd887720b7198827a31726b7b8105e38a7a1d42bb86"
+checksum = "20b5bb9062390c3f3626a8ab90b14a384bce2c5b7281d166d4d295a6c281732e"
 dependencies = [
  "anyhow",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
@@ -665,9 +665,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc8f7d2ded5f9209535e4b3fd4d39c002f30902ff5ce9f64e2c33d549576500"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1287,14 +1287,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.12",
- "regex-syntax 0.8.7",
+ "regex-automata 0.4.13",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
@@ -1308,13 +1308,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.7",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
@@ -1325,9 +1325,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ron"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,9 +665,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "1dc8f7d2ded5f9209535e4b3fd4d39c002f30902ff5ce9f64e2c33d549576500"
 dependencies = [
  "typenum",
  "version_check",
@@ -1584,12 +1584,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1789,9 +1789,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -980,9 +980,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-multimap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -168,11 +168,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -804,7 +804,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1205,7 +1205,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -1297,7 +1297,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
+name = "redb"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fefa3e5ff4a369819c3d6df4195873d6f9abad109f13c0d505dbe119cfabb10"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,13 +1411,16 @@ name = "salusd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "bincode",
+ "bon",
  "clap",
  "config",
  "dirs2",
  "getset",
  "interprocess",
  "libsalus",
+ "redb",
  "rustversion",
  "serde",
  "thiserror 2.0.16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,31 +103,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libloading",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if 1.0.3",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -275,9 +244,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clang-sys"
@@ -609,7 +578,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -679,21 +648,21 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -707,12 +676,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -772,17 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if 1.0.3",
- "libc",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,7 +761,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -838,12 +790,12 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if 1.0.3",
- "windows-targets 0.53.5",
+ "cfg-if 1.0.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -930,15 +882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +889,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -958,7 +901,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -969,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset",
  "pin-utils",
@@ -1030,15 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1016,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1247,7 +1181,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1347,15 +1281,9 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "ordered-multimap",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1519,7 +1447,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -1569,12 +1497,6 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1672,7 +1594,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1717,27 +1639,24 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1921,15 +1840,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,9 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -832,9 +832,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.0.4",
+ "mio 1.1.0",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -895,14 +895,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1479,13 +1479,13 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.0.4",
+ "mio 1.1.0",
  "signal-hook",
 ]
 
@@ -1645,7 +1645,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.0.4",
+ "mio 1.1.0",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -1907,15 +1907,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
  "miniz_oxide",
  "object",
@@ -265,6 +265,12 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -500,6 +506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +543,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs2"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4049c5941d42b500fab4dbe85341aa7eb7b533e2c678529db3c1e88ed1aba8b5"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -572,7 +608,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
 ]
 
 [[package]]
@@ -642,7 +678,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
@@ -653,10 +689,22 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -729,7 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags 2.9.4",
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
 ]
 
@@ -776,6 +824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,8 +841,18 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.4",
+ "libc",
 ]
 
 [[package]]
@@ -799,6 +863,7 @@ dependencies = [
  "aws-lc-rs",
  "bincode",
  "bon",
+ "interprocess",
  "rand",
  "rustversion",
  "ssss",
@@ -832,6 +897,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -894,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
  "memoffset",
  "pin-utils",
@@ -911,6 +985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1003,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -970,6 +1060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,7 +1081,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1055,6 +1151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1172,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1142,6 +1266,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,8 +1284,17 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1161,8 +1305,14 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1188,7 +1338,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "ordered-multimap",
 ]
 
@@ -1253,9 +1403,19 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "clap",
+ "config",
+ "dirs2",
+ "getset",
  "interprocess",
  "libsalus",
+ "rustversion",
+ "serde",
+ "thiserror 2.0.16",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-subscriber-init",
 ]
 
 [[package]]
@@ -1346,9 +1506,18 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.3",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1485,6 +1654,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if 1.0.3",
+]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1790,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-subscriber-init"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a4d66f071a77f1d043dd887720b7198827a31726b7b8105e38a7a1d42bb86"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1631,6 +1883,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
 dependencies = [
  "unicode-ident",
 ]
@@ -1539,9 +1539,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,9 +1539,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "ssss"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193be117bf0ecebab1a073905485c42a58a821014b418f880a0bf2f1574c4311"
+checksum = "a211e39facdcc50db447ad44301213e95ef8217b5e6c799d3051d6e7593229c2"
 dependencies = [
  "anyhow",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "aws-lc-rs",
  "bincode",
  "bon",
+ "getset",
  "interprocess",
  "rand",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ members = ["libsalus", "salus", "salusd"]
 anyhow = "1.0.99"
 bincode = "2.0.1"
 bon = "3.7.2"
+config = "0.15.15"
 interprocess = { version = "2.2.3", features = ["async", "tokio"] }
 rustversion = "1.0.22"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "time"] }
-
 tracing = { version = "0.1.41", features = [
   "max_level_trace",
   "release_max_level_trace",
 ] }
+tracing-cfg = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.100"
 aws-lc-rs = "1.14.0"
 bincode = "2.0.1"
 bon = "3.7.2"
-clap = { version = "4.5.47", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive"] }
 config = "0.15.16"
 getset = "0.1.6"
 interprocess = { version = "2.2.3", features = ["async", "tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["libsalus", "salus", "salusd"]
 
 [workspace.dependencies]
 anyhow = "1.0.99"
+aws-lc-rs = "1.14.0"
 bincode = "2.0.1"
 bon = "3.7.2"
 config = "0.15.15"
@@ -15,4 +16,3 @@ tracing = { version = "0.1.41", features = [
   "max_level_trace",
   "release_max_level_trace",
 ] }
-tracing-cfg = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,11 @@ resolver = "3"
 members = ["libsalus", "salus", "salusd"]
 
 [workspace.dependencies]
-anyhow = "1.0.99"
+anyhow = "1.0.100"
 aws-lc-rs = "1.14.0"
 bincode = "2.0.1"
 bon = "3.7.2"
+clap = { version = "4.5.47", features = ["derive"] }
 config = "0.15.16"
 getset = "0.1.6"
 interprocess = { version = "2.2.3", features = ["async", "tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ anyhow = "1.0.99"
 aws-lc-rs = "1.14.0"
 bincode = "2.0.1"
 bon = "3.7.2"
-config = "0.15.15"
+config = "0.15.16"
+getset = "0.1.6"
 interprocess = { version = "2.2.3", features = ["async", "tokio"] }
 rustversion = "1.0.22"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ members = ["libsalus", "salus", "salusd"]
 
 [workspace.dependencies]
 anyhow = "1.0.100"
-aws-lc-rs = "1.14.0"
+aws-lc-rs = "1.14.1"
 bincode = "2.0.1"
 bon = "3.7.2"
 clap = { version = "4.5.48", features = ["derive"] }
-config = "0.15.16"
+config = "0.15.17"
 getset = "0.1.6"
 interprocess = { version = "2.2.3", features = ["async", "tokio"] }
 rustversion = "1.0.22"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2016 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# salus
+A key/value store protected by secret shares and encryption

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -21,7 +21,7 @@ bincode = { workspace = true }
 bon = { workspace = true }
 getset = { workspace = true }
 interprocess = { workspace = true }
-ssss = "1.0.2"
+ssss = "1.0.3"
 tracing = { workspace = true }
 
 [build-dependencies]

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
-name = "libsalus"
-version = "0.1.0"
+authors = ["Jason Ozias <jason.g.ozias@gmail.com>"]
+categories = ["cryptography"]
+description = "A key/value store protected by secret shares and encryption"
+documentation = "https://docs.rs/salus"
 edition = "2024"
+homepage = "https://github.com/rustyhorde/salus"
+keywords = ["shamir", "store", "cryptography", "redb"]
+license = "MIT OR Apache-2.0"
+name = "libsalus"
+readme = "../README.md"
+repository = "https://github.com/rustyhorde/salus"
+version = "0.1.0"
 
 [features]
 unstable = []

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -8,7 +8,6 @@ unstable = []
 
 [dependencies]
 anyhow = { workspace = true }
-aws-lc-rs = "1.14.0"
 bincode = { workspace = true }
 bon = { workspace = true }
 interprocess = { workspace = true }
@@ -19,4 +18,5 @@ tracing = { workspace = true }
 rustversion = { workspace = true }
 
 [dev-dependencies]
+aws-lc-rs = { workspace = true }
 rand = "0.9.2"

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -10,6 +10,7 @@ unstable = []
 anyhow = { workspace = true }
 bincode = { workspace = true }
 bon = { workspace = true }
+getset = { workspace = true }
 interprocess = { workspace = true }
 ssss = "1.0.2"
 tracing = { workspace = true }

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -8,7 +8,7 @@ unstable = []
 
 [dependencies]
 anyhow = { workspace = true }
-aws-lc-rs = "1.13.3"
+aws-lc-rs = "1.14.0"
 bincode = { workspace = true }
 bon = { workspace = true }
 ssss = "1.0.2"

--- a/libsalus/Cargo.toml
+++ b/libsalus/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 aws-lc-rs = "1.14.0"
 bincode = { workspace = true }
 bon = { workspace = true }
+interprocess = { workspace = true }
 ssss = "1.0.2"
 tracing = { workspace = true }
 

--- a/libsalus/build.rs
+++ b/libsalus/build.rs
@@ -2,8 +2,6 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
     nightly();
-    beta();
-    stable();
 }
 
 #[rustversion::nightly]
@@ -15,26 +13,4 @@ fn nightly() {
 #[rustversion::not(nightly)]
 fn nightly() {
     println!("cargo:rustc-check-cfg=cfg(nightly)");
-}
-
-#[rustversion::beta]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-    println!("cargo:rustc-cfg=beta");
-}
-
-#[rustversion::not(beta)]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-}
-
-#[rustversion::stable]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
-    println!("cargo:rustc-cfg=stable");
-}
-
-#[rustversion::not(stable)]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
 }

--- a/libsalus/src/lib.rs
+++ b/libsalus/src/lib.rs
@@ -124,7 +124,7 @@
         refining_impl_trait_internal,
         refining_impl_trait_reachable,
         renamed_and_removed_lints,
-        repr_transparent_external_private_fields,
+        repr_transparent_non_zst_fields,
         rust_2021_incompatible_closure_captures,
         rust_2021_incompatible_or_patterns,
         rust_2021_prefixes_incompatible_syntax,

--- a/libsalus/src/lib.rs
+++ b/libsalus/src/lib.rs
@@ -238,9 +238,7 @@
     all(nightly, feature = "unstable"),
     deny(rustdoc::missing_doc_code_examples)
 )]
-#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(all(docsrs, nightly), feature(doc_cfg))]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use anyhow::Result;
 use interprocess::local_socket::GenericFilePath;

--- a/libsalus/src/lib.rs
+++ b/libsalus/src/lib.rs
@@ -250,7 +250,7 @@ use interprocess::local_socket::ToFsName;
 mod key;
 mod message;
 
-pub use crate::key::gen_key;
+pub use crate::key::gen_shares;
 pub use crate::key::unlock_key;
 pub use crate::message::Action;
 pub use crate::message::Init;

--- a/libsalus/src/lib.rs
+++ b/libsalus/src/lib.rs
@@ -257,6 +257,7 @@ pub use crate::message::Init;
 pub use crate::message::Response;
 pub use crate::message::Share;
 pub use crate::message::Shares;
+pub use crate::message::Store;
 use interprocess::local_socket::GenericNamespaced;
 use interprocess::local_socket::NameType;
 use interprocess::local_socket::ToNsName;

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -117,4 +117,6 @@ pub enum Response {
     Value(Option<String>),
     /// The key was not found in the store
     KeyNotFound,
+    /// The keys that matched the regex
+    Matches(Vec<String>),
 }

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -96,6 +96,8 @@ pub enum Action {
     Read(String),
     /// Get the threshold
     GetThreshold,
+    /// Find a key
+    FindKey(String),
 }
 
 /// A response from the daemon

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -70,4 +70,6 @@ pub enum Response {
     Success,
     /// Shares
     Shares(Shares),
+    /// The share store is already initialized
+    AlreadyInitialiazed,
 }

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -8,12 +8,16 @@
 
 use bincode::{Decode, Encode};
 use bon::Builder;
+use getset::CopyGetters;
 
 /// The init message to send to the daemon
-#[derive(Builder, Clone, Copy, Debug, Decode, Encode)]
+#[derive(Builder, Clone, Copy, CopyGetters, Debug, Decode, Encode)]
+#[getset(get_copy = "pub")]
 pub struct Init {
+    /// The number of shares to create
     #[builder(default = 5)]
     num_shares: u8,
+    /// The minimum number of shares needed to reconstruct the key
     #[builder(default = 3)]
     threshold: u8,
 }
@@ -74,27 +78,31 @@ impl Store {
 /// A message to send to the daemon
 #[derive(Clone, Debug, Decode, Encode)]
 pub enum Action {
-    /// Init
-    Init(Init),
-    /// Unlock
+    /// Attempt to unlock the store
     Unlock,
-    /// Share
+    /// Send a share to the daemon
     Share(Share),
-    /// Genkey
-    Genkey,
-    /// Store
+    /// Generate the salus shares
+    GenShares(u8, u8),
+    /// Store an encrypted value
     Store(Store),
+    /// Read an encrypted value
+    Read(String),
+    /// Get the threshold
+    GetThreshold,
 }
 
 /// A response from the daemon
 #[derive(Clone, Debug, Decode, Encode)]
 pub enum Response {
     /// Error
-    Error,
+    Error(String),
     /// Success
     Success,
     /// Shares
     Shares(Shares),
     /// The share store is already initialized
     AlreadyInitialiazed,
+    /// The threshold
+    Threshold(u8),
 }

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -33,17 +33,41 @@ impl Share {
     }
 }
 
+/// A share message to send to the daemon
+#[derive(Builder, Clone, Debug, Decode, Encode)]
+pub struct Shares {
+    #[builder(into)]
+    shares: Vec<String>,
+}
+
+impl Shares {
+    /// Get the shares
+    #[must_use]
+    pub fn shares(&self) -> &[String] {
+        &self.shares
+    }
+}
+
 /// A message to send to the daemon
 #[derive(Clone, Debug, Decode, Encode)]
-pub enum Message {
-    /// Init message
+pub enum Action {
+    /// Init
     Init(Init),
-    /// Unlock message
+    /// Unlock
     Unlock,
-    /// Success
-    Success,
-    /// Error
-    Error,
     /// Share
     Share(Share),
+    /// Genkey
+    Genkey,
+}
+
+/// A response from the daemon
+#[derive(Clone, Debug, Decode, Encode)]
+pub enum Response {
+    /// Error
+    Error,
+    /// Success
+    Success,
+    /// Shares
+    Shares(Shares),
 }

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -111,4 +111,8 @@ pub enum Response {
     AlreadyInitialiazed,
     /// The threshold
     Threshold(u8),
+    /// The value read from the store
+    Value(Option<String>),
+    /// The key was not found in the store
+    KeyNotFound,
 }

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -48,6 +48,29 @@ impl Shares {
     }
 }
 
+/// A store message to send to the daemon
+#[derive(Builder, Clone, Debug, Decode, Encode)]
+pub struct Store {
+    #[builder(into)]
+    key: String,
+    #[builder(into)]
+    value: String,
+}
+
+impl Store {
+    /// Get the key
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Get the value
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
 /// A message to send to the daemon
 #[derive(Clone, Debug, Decode, Encode)]
 pub enum Action {
@@ -59,6 +82,8 @@ pub enum Action {
     Share(Share),
     /// Genkey
     Genkey,
+    /// Store
+    Store(Store),
 }
 
 /// A response from the daemon

--- a/libsalus/src/message/mod.rs
+++ b/libsalus/src/message/mod.rs
@@ -73,6 +73,12 @@ impl Store {
     pub fn value(&self) -> &str {
         &self.value
     }
+
+    /// Get the key and value as a tuple
+    #[must_use]
+    pub fn into_parts(self) -> (String, String) {
+        (self.key, self.value)
+    }
 }
 
 /// A message to send to the daemon

--- a/salus/Cargo.toml
+++ b/salus/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
-name = "salus"
-version = "0.1.0"
+authors = ["Jason Ozias <jason.g.ozias@gmail.com>"]
+categories = ["cryptography"]
+description = "The command line client for the salusd daemon"
+documentation = "https://docs.rs/salus"
 edition = "2024"
+homepage = "https://github.com/rustyhorde/salus"
+keywords = ["shamir", "store", "cryptography", "redb"]
+license = "MIT OR Apache-2.0"
+name = "salus"
+readme = "../README.md"
+repository = "https://github.com/rustyhorde/salus"
+version = "0.1.0"
 
 [features]
 unstable = []

--- a/salus/Cargo.toml
+++ b/salus/Cargo.toml
@@ -10,13 +10,13 @@ unstable = []
 anyhow = { workspace = true }
 bincode = { workspace = true }
 bon = { workspace = true }
-clap = { version = "4.5.47", features = ["derive"] }
+clap = { workspace = true }
 config = { workspace = true }
 crossterm = "0.29.0"
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
 scanpw = "1.0.0"
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-std"] }
 tracing = { workspace = true }
 
 [build-dependencies]

--- a/salus/Cargo.toml
+++ b/salus/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 bon = { workspace = true }
 clap = { version = "4.5.47", features = ["derive"] }
-config = "0.15.15"
+config = { workspace = true }
 crossterm = "0.29.0"
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }

--- a/salus/build.rs
+++ b/salus/build.rs
@@ -2,8 +2,6 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
     nightly();
-    beta();
-    stable();
 }
 
 #[rustversion::nightly]
@@ -15,26 +13,4 @@ fn nightly() {
 #[rustversion::not(nightly)]
 fn nightly() {
     println!("cargo:rustc-check-cfg=cfg(nightly)");
-}
-
-#[rustversion::beta]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-    println!("cargo:rustc-cfg=beta");
-}
-
-#[rustversion::not(beta)]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-}
-
-#[rustversion::stable]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
-    println!("cargo:rustc-cfg=stable");
-}
-
-#[rustversion::not(stable)]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
 }

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -50,6 +50,7 @@ impl Inter {
             if let Err(e) = blah().await {
                 eprintln!("There was an error when sending: {e}");
             }
+            drop(sender);
         });
 
         // Allocate a sizeable buffer for receiving. This size should be enough and should be easy to

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -9,8 +9,10 @@
 use anyhow::Result;
 use bincode::{config::standard, decode_from_slice, encode_to_vec};
 use bon::Builder;
+use crossterm::style::{Color, Stylize, style};
 use interprocess::local_socket::{tokio::Stream, traits::tokio::Stream as _};
-use libsalus::{Action, Response, socket_name};
+use libsalus::{Action, Response, Share, Store, socket_name};
+use scanpw::scanpw;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 
 #[derive(Builder, Clone, Debug)]
@@ -57,5 +59,106 @@ impl Inter {
             Ok((msg, _size)) => Ok(msg),
             Err(e) => Err(e),
         }
+    }
+
+    pub(crate) async fn shares(&self, num_shares: u8, threshold: u8) -> Result<()> {
+        match self.send(Action::GenShares(num_shares, threshold)).await? {
+            Response::Shares(shares) => {
+                println!("{}", "These are your salus key shares.  Record them somewhere safe!  They will not be shown again.".green().bold());
+                println!();
+                for share in shares.shares() {
+                    println!("{share}");
+                }
+            }
+            Response::AlreadyInitialiazed => {
+                println!(
+                    "{}",
+                    "The shares for this salus store have already been generated"
+                        .red()
+                        .bold()
+                );
+            }
+            Response::Error(error) => {
+                eprintln!("Error occurred while generating shares: {error}");
+            }
+            _ => {
+                eprintln!("Unexpected response from salusd");
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn unlock(&self) -> Result<()> {
+        let mut threshold = 3;
+        if let Response::Threshold(th) = self.send(Action::GetThreshold).await? {
+            threshold = th;
+        }
+
+        let th_prompt = format!("Enter your {threshold} shares, one per prompt");
+        println!("{}", th_prompt.green().bold());
+        println!();
+        for i in 0..threshold {
+            let share_in = scanpw!(
+                "{}",
+                style(format!("Enter share {}/{threshold}: ", i + 1)).green()
+            );
+            let share = Share::builder().share(share_in).build();
+            let message = Action::Share(share);
+            let _unused = self.send(message).await?;
+        }
+        let _unused = self.send(Action::Unlock).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn store(&self, key: String, value: String) -> Result<()> {
+        let message = Action::Store(Store::builder().key(key).value(value).build());
+        if let Response::Error(error) = self.send(message).await? {
+            eprintln!("Error occurred while storing value: {error}");
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn read(&self, key_opt: Option<String>) -> Result<()> {
+        // TODO: if key is not provided, prompt for it
+        if let Some(key) = key_opt {
+            let message = Action::Read(key.clone());
+            match self.send(message).await? {
+                Response::Value(value) => {
+                    if let Some(val) = value {
+                        let value_style = style(val).with(Color::Green).bold();
+                        println!("{}", "Value: ".green());
+                        println!("{value_style}");
+                    } else {
+                        let not_found_style =
+                            style(format!("No value found for '{key}'")).red().bold();
+                        println!("{not_found_style}");
+                    }
+                }
+                Response::KeyNotFound => {
+                    let not_found_style = style(format!("Key '{key}' not found")).red().bold();
+                    println!("{not_found_style}");
+                }
+                Response::Error(error) => {
+                    eprintln!("Error occurred while reading value: {error}");
+                }
+                _ => {
+                    eprintln!("Unexpected response from salusd");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn find(&self, regex: String) -> Result<()> {
+        let message = Action::FindKey(regex.clone());
+        match self.send(message).await? {
+            Response::Error(error) => {
+                eprintln!("Error occurred while finding key: {error}");
+            }
+            _ => {
+                eprintln!("Unexpected response from salusd");
+            }
+        }
+        Ok(())
     }
 }

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -47,10 +47,6 @@ impl Inter {
             drop(sender);
         });
 
-        // Allocate a sizeable buffer for receiving. This size should be enough and should be easy to
-        // find for the allocator.
-        // let mut buffer = String::with_capacity(128);
-
         // Describe the receive operation as receiving until a newline into our buffer.
         let mut msg_buf = Vec::new();
         let _msg_size = recver.read_to_end(&mut msg_buf).await?;

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -19,6 +19,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 #[derive(Builder, Clone, Debug)]
 pub(crate) struct Inter {
     #[builder(into, default = "/var/run/salus.sock")]
+    #[allow(dead_code)]
     name: String,
 }
 

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -152,6 +152,20 @@ impl Inter {
     pub(crate) async fn find(&self, regex: String) -> Result<()> {
         let message = Action::FindKey(regex.clone());
         match self.send(message).await? {
+            Response::Matches(matches) => {
+                if matches.is_empty() {
+                    let no_match_style = style(format!("No keys matched regex '{regex}'"))
+                        .red()
+                        .bold();
+                    println!("{no_match_style}");
+                } else {
+                    println!("{}", "Matching keys:".green().bold());
+                    for key in matches {
+                        let key_style = style(key).with(Color::Green).bold();
+                        println!("{key_style}");
+                    }
+                }
+            }
             Response::Error(error) => {
                 eprintln!("Error occurred while finding key: {error}");
             }

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -29,9 +29,9 @@ impl Inter {
         let base_socket = "salus.sock";
         let ns_prefix = "/var/run/";
         let name = if GenericNamespaced::is_supported() {
-            format!("{}{}", ns_prefix, base_socket).to_ns_name::<GenericNamespaced>()?
+            format!("{ns_prefix}{base_socket}").to_ns_name::<GenericNamespaced>()?
         } else {
-            format!("/tmp/{}", base_socket).to_fs_name::<GenericFilePath>()?
+            format!("/tmp/{base_socket}").to_fs_name::<GenericFilePath>()?
         };
 
         // Await this here since we can't do a whole lot without a connection.

--- a/salus/src/inter/mod.rs
+++ b/salus/src/inter/mod.rs
@@ -25,10 +25,12 @@ pub(crate) struct Inter {
 impl Inter {
     pub(crate) async fn send(&self, message: Message) -> Result<()> {
         // Pick a name.
+        let base_socket = "salus.sock";
+        let ns_prefix = "/var/run/";
         let name = if GenericNamespaced::is_supported() {
-            self.name.clone().to_ns_name::<GenericNamespaced>()?
+            format!("{}{}", ns_prefix, base_socket).to_ns_name::<GenericNamespaced>()?
         } else {
-            format!("/tmp/{}", self.name).to_fs_name::<GenericFilePath>()?
+            format!("/tmp/{}", base_socket).to_fs_name::<GenericFilePath>()?
         };
 
         // Await this here since we can't do a whole lot without a connection.

--- a/salus/src/main.rs
+++ b/salus/src/main.rs
@@ -124,7 +124,7 @@
         refining_impl_trait_internal,
         refining_impl_trait_reachable,
         renamed_and_removed_lints,
-        repr_transparent_external_private_fields,
+        repr_transparent_non_zst_fields,
         rust_2021_incompatible_closure_captures,
         rust_2021_incompatible_or_patterns,
         rust_2021_prefixes_incompatible_syntax,

--- a/salus/src/main.rs
+++ b/salus/src/main.rs
@@ -238,9 +238,7 @@
     all(nightly, feature = "unstable"),
     deny(rustdoc::missing_doc_code_examples)
 )]
-#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(all(docsrs, nightly), feature(doc_cfg))]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use crate::error::{clap_or_error, success};
 use anyhow::Result;

--- a/salus/src/runtime/cli.rs
+++ b/salus/src/runtime/cli.rs
@@ -69,7 +69,7 @@ impl Source for Cli {
     }
 }
 
-#[derive(Clone, Copy, Debug, Subcommand)]
+#[derive(Clone, Debug, Subcommand)]
 pub(crate) enum Commands {
     Genkey,
     Init {
@@ -81,4 +81,12 @@ pub(crate) enum Commands {
         threshold: u8,
     },
     Unlock,
+    Store {
+        /// The key to store the value under
+        #[arg(short, long)]
+        key: String,
+        /// The value to store
+        #[arg(short, long)]
+        value: String,
+    },
 }

--- a/salus/src/runtime/cli.rs
+++ b/salus/src/runtime/cli.rs
@@ -88,4 +88,9 @@ pub(crate) enum Commands {
         #[arg(short, long)]
         value: String,
     },
+    Read {
+        /// The key to read the value from
+        #[arg(short, long)]
+        key_opt: Option<String>,
+    },
 }

--- a/salus/src/runtime/cli.rs
+++ b/salus/src/runtime/cli.rs
@@ -93,4 +93,9 @@ pub(crate) enum Commands {
         #[arg(short, long)]
         key_opt: Option<String>,
     },
+    Find {
+        /// The regex to find keys with
+        #[arg(index = 1)]
+        regex: String,
+    },
 }

--- a/salus/src/runtime/cli.rs
+++ b/salus/src/runtime/cli.rs
@@ -71,8 +71,7 @@ impl Source for Cli {
 
 #[derive(Clone, Debug, Subcommand)]
 pub(crate) enum Commands {
-    Genkey,
-    Init {
+    Shares {
         /// The number of shares to create
         #[arg(short, long, default_value = "5")]
         num_shares: u8,

--- a/salus/src/runtime/mod.rs
+++ b/salus/src/runtime/mod.rs
@@ -11,7 +11,7 @@ use std::ffi::OsString;
 use anyhow::Result;
 use clap::Parser;
 use crossterm::style::{Stylize, style};
-use libsalus::{Action, Init, Response, Share};
+use libsalus::{Action, Init, Response, Share, Store};
 use scanpw::scanpw;
 
 use crate::{
@@ -77,6 +77,12 @@ where
                 let _unused = inter.send(message).await?;
             }
             let _unused = inter.send(Action::Unlock).await?;
+        }
+        Commands::Store { key, value } => {
+            let message = Action::Store(Store::builder().key(key).value(value).build());
+            if let Response::Error = inter.send(message).await? {
+                eprintln!("Error occurred while storing value");
+            }
         }
     }
 

--- a/salus/src/runtime/mod.rs
+++ b/salus/src/runtime/mod.rs
@@ -10,9 +10,6 @@ use std::ffi::OsString;
 
 use anyhow::Result;
 use clap::Parser;
-use crossterm::style::{Color, Stylize, style};
-use libsalus::{Action, Response, Share, Store};
-use scanpw::scanpw;
 
 use crate::{
     inter::Inter,
@@ -39,92 +36,11 @@ where
         Commands::Shares {
             num_shares,
             threshold,
-        } => match inter.send(Action::GenShares(num_shares, threshold)).await? {
-            Response::Shares(shares) => {
-                println!("{}", "These are your salus key shares.  Record them somewhere safe!  They will not be shown again.".green().bold());
-                println!();
-                for share in shares.shares() {
-                    println!("{share}");
-                }
-            }
-            Response::AlreadyInitialiazed => {
-                println!(
-                    "{}",
-                    "The shares for this salus store have already been generated"
-                        .red()
-                        .bold()
-                );
-            }
-            Response::Error(error) => {
-                eprintln!("Error occurred while generating shares: {error}");
-            }
-            _ => {
-                eprintln!("Unexpected response from salusd");
-            }
-        },
-        Commands::Unlock => {
-            let mut threshold = 3;
-            if let Response::Threshold(th) = inter.send(Action::GetThreshold).await? {
-                threshold = th;
-            }
-
-            let th_prompt = format!("Enter your {threshold} shares, one per prompt");
-            println!("{}", th_prompt.green().bold());
-            println!();
-            for i in 0..threshold {
-                let share_in = scanpw!(
-                    "{}",
-                    style(format!("Enter share {}/{threshold}: ", i + 1)).green()
-                );
-                let share = Share::builder().share(share_in).build();
-                let message = Action::Share(share);
-                let _unused = inter.send(message).await?;
-            }
-            let _unused = inter.send(Action::Unlock).await?;
-        }
-        Commands::Store { key, value } => {
-            let message = Action::Store(Store::builder().key(key).value(value).build());
-            if let Response::Error(error) = inter.send(message).await? {
-                eprintln!("Error occurred while storing value: {error}");
-            }
-        }
-        Commands::Read { key_opt } => {
-            // TODO: if key is not provided, prompt for it
-            // println!("Enter the key you wish to read: ");
-            // let mut key = String::new();
-            // let stdin = io::stdin();
-            // let _bytes_read = stdin
-            //     .lock()
-            //     .read_line(&mut key)
-            //     .with_context(|| "Failed to read line")?;
-            // let key = key.trim().to_string();
-            if let Some(key) = key_opt {
-                let message = Action::Read(key.clone());
-                match inter.send(message).await? {
-                    Response::Value(value) => {
-                        if let Some(val) = value {
-                            let value_style = style(val).with(Color::Green).bold();
-                            println!("{}", "Value: ".green());
-                            println!("{value_style}");
-                        } else {
-                            let not_found_style =
-                                style(format!("No value found for '{key}'")).red().bold();
-                            println!("{not_found_style}");
-                        }
-                    }
-                    Response::KeyNotFound => {
-                        let not_found_style = style(format!("Key '{key}' not found")).red().bold();
-                        println!("{not_found_style}");
-                    }
-                    Response::Error(error) => {
-                        eprintln!("Error occurred while reading value: {error}");
-                    }
-                    _ => {
-                        eprintln!("Unexpected response from salusd");
-                    }
-                }
-            }
-        }
+        } => inter.shares(num_shares, threshold).await?,
+        Commands::Unlock => inter.unlock().await?,
+        Commands::Store { key, value } => inter.store(key, value).await?,
+        Commands::Read { key_opt } => inter.read(key_opt).await?,
+        Commands::Find { regex } => inter.find(regex).await?,
     }
 
     Ok(())

--- a/salus/src/runtime/mod.rs
+++ b/salus/src/runtime/mod.rs
@@ -60,6 +60,9 @@ where
                     println!("{share}");
                 }
             }
+            Response::AlreadyInitialiazed => {
+                println!("{}", "The share store is already initialized".red().bold());
+            }
             _ => {
                 println!("Received unexpected response");
             }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -8,19 +8,22 @@ unstable = []
 
 [dependencies]
 anyhow = { workspace = true }
+aws-lc-rs = { workspace = true }
 bincode = { workspace = true }
+bon = { workspace = true }
 clap = { version = "4.5.47", features = ["derive"] }
 config = { workspace = true }
 dirs2 = "3.0.1"
 getset = "0.1.6"
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
+redb = "3.0.1"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "=0.3.19", features = ["env-filter", "fmt", "time"] }
-tracing-subscriber-init = { version = "0.1.3", features = ["time"] }
+tracing-subscriber-init = { version = "0.1.4", features = ["time"] }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -14,11 +14,11 @@ bon = { workspace = true }
 clap = { version = "4.5.47", features = ["derive"] }
 config = { workspace = true }
 dirs2 = "3.0.1"
-getset = "0.1.6"
+getset = { workspace = true }
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
 redb = "3.0.1"
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.224", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
-name = "salusd"
-version = "0.1.0"
+authors = ["Jason Ozias <jason.g.ozias@gmail.com>"]
+categories = ["cryptography"]
+description = "The daemon for the secret store"
+documentation = "https://docs.rs/salus"
 edition = "2024"
+homepage = "https://github.com/rustyhorde/salus"
+keywords = ["shamir", "store", "cryptography", "redb"]
+license = "MIT OR Apache-2.0"
+name = "salusd"
+readme = "../README.md"
+repository = "https://github.com/rustyhorde/salus"
+version = "0.1.0"
 
 [features]
 unstable = []

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -11,14 +11,14 @@ anyhow = { workspace = true }
 aws-lc-rs = { workspace = true }
 bincode = { workspace = true }
 bon = { workspace = true }
-clap = { version = "4.5.47", features = ["derive"] }
+clap = { workspace = true }
 config = { workspace = true }
 dirs2 = "3.0.1"
 getset = { workspace = true }
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
-redb = "3.0.1"
-serde = { version = "1.0.224", features = ["derive"] }
+redb = "3.0.2"
+serde = { version = "1.0.225", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -27,6 +27,7 @@ getset = { workspace = true }
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
 redb = "3.0.2"
+regex = "1.11.2"
 serde = { version = "1.0.226", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -27,7 +27,7 @@ getset = { workspace = true }
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
 redb = "3.0.2"
-serde = { version = "1.0.225", features = ["derive"] }
+serde = { version = "1.0.226", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -26,14 +26,14 @@ dirs2 = "3.0.1"
 getset = { workspace = true }
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
-redb = "3.0.2"
-regex = "1.11.2"
-serde = { version = "1.0.226", features = ["derive"] }
+redb = "3.1.0"
+regex = "1.11.3"
+serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.16"
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "=0.3.19", features = ["env-filter", "fmt", "time"] }
-tracing-subscriber-init = { version = "0.1.4", features = ["time"] }
+tracing-subscriber-init = { version = "0.1.5", features = ["time"] }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/salusd/Cargo.toml
+++ b/salusd/Cargo.toml
@@ -3,9 +3,24 @@ name = "salusd"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+unstable = []
+
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
+clap = { version = "4.5.47", features = ["derive"] }
+config = { workspace = true }
+dirs2 = "3.0.1"
+getset = "0.1.6"
 interprocess = { workspace = true }
 libsalus = { path = "../libsalus" }
-tokio = { workspace = true }
+serde = { version = "1.0.219", features = ["derive"] }
+thiserror = "2.0.16"
+tokio = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "=0.3.19", features = ["env-filter", "fmt", "time"] }
+tracing-subscriber-init = { version = "0.1.3", features = ["time"] }
+
+[build-dependencies]
+rustversion = { workspace = true }

--- a/salusd/build.rs
+++ b/salusd/build.rs
@@ -1,0 +1,40 @@
+pub fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
+    nightly();
+    beta();
+    stable();
+}
+
+#[rustversion::nightly]
+fn nightly() {
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
+    println!("cargo:rustc-cfg=nightly");
+}
+
+#[rustversion::not(nightly)]
+fn nightly() {
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
+}
+
+#[rustversion::beta]
+fn beta() {
+    println!("cargo:rustc-check-cfg=cfg(beta)");
+    println!("cargo:rustc-cfg=beta");
+}
+
+#[rustversion::not(beta)]
+fn beta() {
+    println!("cargo:rustc-check-cfg=cfg(beta)");
+}
+
+#[rustversion::stable]
+fn stable() {
+    println!("cargo:rustc-check-cfg=cfg(stable)");
+    println!("cargo:rustc-cfg=stable");
+}
+
+#[rustversion::not(stable)]
+fn stable() {
+    println!("cargo:rustc-check-cfg=cfg(stable)");
+}

--- a/salusd/build.rs
+++ b/salusd/build.rs
@@ -2,8 +2,6 @@ pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
     nightly();
-    beta();
-    stable();
 }
 
 #[rustversion::nightly]
@@ -15,26 +13,4 @@ fn nightly() {
 #[rustversion::not(nightly)]
 fn nightly() {
     println!("cargo:rustc-check-cfg=cfg(nightly)");
-}
-
-#[rustversion::beta]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-    println!("cargo:rustc-cfg=beta");
-}
-
-#[rustversion::not(beta)]
-fn beta() {
-    println!("cargo:rustc-check-cfg=cfg(beta)");
-}
-
-#[rustversion::stable]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
-    println!("cargo:rustc-cfg=stable");
-}
-
-#[rustversion::not(stable)]
-fn stable() {
-    println!("cargo:rustc-check-cfg=cfg(stable)");
 }

--- a/salusd/src/config/mod.rs
+++ b/salusd/src/config/mod.rs
@@ -48,6 +48,8 @@ pub(crate) struct ConfigSalusd {
     quiet: u8,
     #[getset(get_copy = "pub(crate)")]
     enable_std_output: bool,
+    #[getset(get_copy = "pub(crate)")]
+    key_timeout: u64,
     #[getset(get = "pub(crate)")]
     tracing: Tracing,
 }

--- a/salusd/src/config/mod.rs
+++ b/salusd/src/config/mod.rs
@@ -32,6 +32,12 @@ pub(crate) trait PathDefaults {
     fn default_tracing_path(&self) -> String;
     /// The default log file name to use
     fn default_tracing_file_name(&self) -> String;
+    /// The absolute path to use for the database
+    fn database_absolute_path(&self) -> Option<String>;
+    /// The default database path to use
+    fn default_database_path(&self) -> String;
+    /// The default database file name to use
+    fn default_database_file_name(&self) -> String;
 }
 
 #[derive(Clone, CopyGetters, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]

--- a/salusd/src/config/mod.rs
+++ b/salusd/src/config/mod.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use config::{Config, Environment, File, FileFormat, Source};
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+use tracing_subscriber_init::TracingConfig;
+
+use crate::{error::Error, utils::to_path_buf};
+
+/// Trait to allow default paths to be supplied to [`load`]
+pub(crate) trait PathDefaults {
+    /// Environment variable prefix
+    fn env_prefix(&self) -> String;
+    /// The absolute path to use for the config file
+    fn config_absolute_path(&self) -> Option<String>;
+    /// The default file path to use
+    fn default_file_path(&self) -> String;
+    /// The default file name to use
+    fn default_file_name(&self) -> String;
+    /// The abolute path to use for tracing output
+    fn tracing_absolute_path(&self) -> Option<String>;
+    /// The default logging path to use
+    fn default_tracing_path(&self) -> String;
+    /// The default log file name to use
+    fn default_tracing_file_name(&self) -> String;
+}
+
+#[derive(Clone, CopyGetters, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]
+pub(crate) struct ConfigSalusd {
+    #[getset(get_copy = "pub(crate)")]
+    verbose: u8,
+    #[getset(get_copy = "pub(crate)")]
+    quiet: u8,
+    #[getset(get_copy = "pub(crate)")]
+    enable_std_output: bool,
+    #[getset(get = "pub(crate)")]
+    tracing: Tracing,
+}
+
+impl TracingConfig for ConfigSalusd {
+    fn quiet(&self) -> u8 {
+        self.quiet
+    }
+
+    fn verbose(&self) -> u8 {
+        self.verbose
+    }
+
+    fn with_target(&self) -> bool {
+        self.tracing.with_target
+    }
+
+    fn with_thread_ids(&self) -> bool {
+        self.tracing.with_thread_ids
+    }
+
+    fn with_thread_names(&self) -> bool {
+        self.tracing.with_thread_names
+    }
+
+    fn with_line_number(&self) -> bool {
+        self.tracing.with_line_number
+    }
+
+    fn with_level(&self) -> bool {
+        self.tracing.with_level
+    }
+}
+
+/// Tracing configuration
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, CopyGetters, Debug, Default, Deserialize, Eq, Getters, PartialEq, Serialize)]
+pub(crate) struct Tracing {
+    /// Should we trace the event target
+    #[getset(get_copy = "pub(crate)")]
+    with_target: bool,
+    /// Should we trace the thread id
+    #[getset(get_copy = "pub(crate)")]
+    with_thread_ids: bool,
+    /// Should we trace the thread names
+    #[getset(get_copy = "pub(crate)")]
+    with_thread_names: bool,
+    /// Should we trace the line numbers
+    #[getset(get_copy = "pub(crate)")]
+    with_line_number: bool,
+    /// Should we trace the level
+    #[getset(get_copy = "pub(crate)")]
+    with_level: bool,
+    /// Additional tracing directives
+    #[getset(get = "pub(crate)")]
+    directives: Option<String>,
+}
+
+/// Load the configuration
+pub(crate) fn load<'a, S, T, D>(cli: &S, defaults: &D) -> Result<T>
+where
+    T: Deserialize<'a>,
+    S: Source + Clone + Send + Sync + 'static,
+    D: PathDefaults,
+{
+    let config_file_path = config_file_path(defaults)?;
+    let config = Config::builder()
+        .add_source(
+            Environment::with_prefix(&defaults.env_prefix())
+                .separator("_")
+                .try_parsing(true),
+        )
+        .add_source(cli.clone())
+        .add_source(File::from(config_file_path).format(FileFormat::Toml))
+        .build()
+        .with_context(|| Error::ConfigBuild)?;
+    config
+        .try_deserialize::<T>()
+        .with_context(|| Error::ConfigDeserialize)
+}
+
+fn config_file_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let default_fn = || -> Result<PathBuf> { default_config_file_path(defaults) };
+    defaults
+        .config_absolute_path()
+        .as_ref()
+        .map_or_else(default_fn, to_path_buf)
+}
+
+fn default_config_file_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let mut config_file_path = dirs2::config_dir().ok_or(Error::ConfigDir)?;
+    config_file_path.push(defaults.default_file_path());
+    config_file_path.push(defaults.default_file_name());
+    let _ = config_file_path.set_extension("toml");
+    Ok(config_file_path)
+}

--- a/salusd/src/db/mod.rs
+++ b/salusd/src/db/mod.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::{
+    borrow::Borrow,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::Result;
+use bon::Builder;
+use getset::Getters;
+use redb::{AccessGuard, Database, Key, ReadableDatabase, TableDefinition, TypeName, Value};
+
+use crate::{config::PathDefaults, utils::to_path_buf};
+
+#[derive(Builder, Clone, Debug, Getters)]
+#[getset(get = "pub(crate)")]
+pub(crate) struct SalusVal {
+    #[builder(into)]
+    nonce: [u8; 12],
+    #[builder(into)]
+    ciphertext: Vec<u8>,
+}
+
+impl Value for SalusVal {
+    type SelfType<'a>
+        = SalusVal
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        let nonce = data[0..12].try_into().expect("slice with incorrect length");
+        let ciphertext = data[12..].to_vec();
+        SalusVal { nonce, ciphertext }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        let mut bytes = Vec::with_capacity(12 + value.ciphertext.len());
+        bytes.extend_from_slice(&value.nonce);
+        bytes.extend_from_slice(&value.ciphertext);
+        bytes
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("SalusVal")
+    }
+}
+
+pub(crate) const SALUS_CONFIG_TABLE_DEF: TableDefinition<'_, &str, bool> =
+    TableDefinition::new("salus_config");
+
+pub(crate) const SALUS_VAL_TABLE_DEF: TableDefinition<'_, &str, SalusVal> =
+    TableDefinition::new("salus_store");
+
+pub(crate) fn initialize_redb<T: PathDefaults>(defaults: &T) -> Result<Arc<Mutex<Database>>> {
+    let redb_path = database_absolute_path(defaults)?;
+    let db = Database::create(redb_path)?;
+    Ok(Arc::new(Mutex::new(db)))
+}
+
+pub(crate) fn write_value<'a, K, V>(
+    db: &mut Database,
+    table_def: TableDefinition<'_, K, V>,
+    key: K,
+    value: V,
+) -> Result<()>
+where
+    K: Key + Borrow<K::SelfType<'a>>,
+    V: Value + Borrow<V::SelfType<'a>>,
+{
+    let write_txn = db.begin_write()?;
+    {
+        let mut table = write_txn.open_table(table_def)?;
+        let _old_val = table.insert(key, value)?;
+    }
+    write_txn.commit()?;
+    Ok(())
+}
+
+pub(crate) fn read_value<'a, K, V>(
+    db: &Database,
+    table_def: TableDefinition<'_, K, V>,
+    key: K,
+) -> Result<Option<AccessGuard<'a, V>>>
+where
+    K: Key + Borrow<K::SelfType<'a>>,
+    V: Value<SelfType<'a> = V> + Borrow<V::SelfType<'a>>,
+{
+    let read_txn = db.begin_read()?;
+    let table = read_txn.open_table(table_def)?;
+    if let Some(value) = table.get(key)? {
+        Ok(Some(value))
+    } else {
+        Ok(None)
+    }
+}
+
+fn database_absolute_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let default_fn = || -> Result<PathBuf> { default_database_absolute_path(defaults) };
+    defaults
+        .database_absolute_path()
+        .as_ref()
+        .map_or_else(default_fn, to_path_buf)
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn default_database_absolute_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let mut database_file_path = PathBuf::from(defaults.default_database_path());
+    database_file_path.push(defaults.default_database_file_name());
+    let _ = database_file_path.set_extension("redb");
+    Ok(database_file_path)
+}

--- a/salusd/src/db/values/config.rs
+++ b/salusd/src/db/values/config.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use anyhow::Result;
+use bincode::{
+    Decode, Encode, config::standard, decode_from_slice, encode_into_slice, encode_to_vec,
+};
+use bon::Builder;
+use getset::Getters;
+use redb::{TypeName, Value};
+
+#[derive(Builder, Clone, Debug, Decode, Encode, Getters)]
+pub(crate) struct ConfigVal {
+    value: Vec<u8>,
+}
+
+impl ConfigVal {
+    pub(crate) fn to_value<T: Decode<()>>(&self) -> Result<T> {
+        let (res, _): (T, usize) = decode_from_slice(&self.value, standard())?;
+        Ok(res)
+    }
+
+    pub(crate) fn from_value<T: Encode>(value: T) -> Result<Self> {
+        let value = encode_to_vec(&value, standard())?;
+        Ok(Self::builder().value(value).build())
+    }
+}
+
+impl Value for ConfigVal {
+    type SelfType<'a>
+        = ConfigVal
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        let res: (ConfigVal, usize) = decode_from_slice(data, standard()).unwrap();
+        res.0
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        let mut bytes = [0u8; 100];
+        let length = encode_into_slice(value, &mut bytes, standard()).unwrap();
+        bytes[..length].to_vec()
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("ConfigVal")
+    }
+}

--- a/salusd/src/db/values/mod.rs
+++ b/salusd/src/db/values/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+pub(crate) mod config;
+pub(crate) mod salus;

--- a/salusd/src/db/values/salus.rs
+++ b/salusd/src/db/values/salus.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use bon::Builder;
+use getset::{CopyGetters, Getters};
+use redb::{TypeName, Value};
+
+#[derive(Builder, Clone, CopyGetters, Debug, Getters)]
+pub(crate) struct SalusVal {
+    #[builder(into)]
+    #[getset(get_copy = "pub(crate)")]
+    nonce: [u8; 12],
+    #[builder(into)]
+    #[getset(get = "pub(crate)")]
+    ciphertext: Vec<u8>,
+}
+
+impl Value for SalusVal {
+    type SelfType<'a>
+        = SalusVal
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        let nonce = data[0..12].try_into().expect("slice with incorrect length");
+        let ciphertext = data[12..].to_vec();
+        SalusVal { nonce, ciphertext }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        let mut bytes = Vec::with_capacity(12 + value.ciphertext.len());
+        bytes.extend_from_slice(&value.nonce);
+        bytes.extend_from_slice(&value.ciphertext);
+        bytes
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::new("SalusVal")
+    }
+}

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use clap::error::ErrorKind;
+use tracing::error;
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("There is no valid config directory")]
+    ConfigDir,
+    #[error("Unable to build a valid configuration")]
+    ConfigBuild,
+    #[error("Unable to deserialize config")]
+    ConfigDeserialize,
+    #[error("Unable to load a valid configuration")]
+    ConfigLoad,
+    #[error("Unable to initialize tracing")]
+    TracingInit,
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn clap_or_error(err: anyhow::Error) -> i32 {
+    let disp_err = || {
+        eprint!("{err:?}");
+        1
+    };
+    match err.downcast_ref::<clap::Error>() {
+        Some(e) => match e.kind() {
+            ErrorKind::DisplayHelp => {
+                eprint!("{e}");
+                0
+            }
+            ErrorKind::DisplayVersion => 0,
+            ErrorKind::InvalidValue
+            | ErrorKind::UnknownArgument
+            | ErrorKind::InvalidSubcommand
+            | ErrorKind::NoEquals
+            | ErrorKind::ValueValidation
+            | ErrorKind::TooManyValues
+            | ErrorKind::TooFewValues
+            | ErrorKind::WrongNumberOfValues
+            | ErrorKind::ArgumentConflict
+            | ErrorKind::MissingRequiredArgument
+            | ErrorKind::MissingSubcommand
+            | ErrorKind::InvalidUtf8
+            | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            | ErrorKind::Io
+            | ErrorKind::Format => disp_err(),
+            _ => {
+                error!("Unknown ErrorKind");
+                disp_err()
+            }
+        },
+        None => disp_err(),
+    }
+}
+
+pub(crate) fn success((): ()) -> i32 {
+    0
+}
+
+#[cfg(test)]
+mod test {
+    use super::{clap_or_error, success};
+    use anyhow::{Error, anyhow};
+    use clap::{
+        Command,
+        error::ErrorKind::{self, DisplayHelp, DisplayVersion},
+    };
+
+    #[test]
+    fn success_works() {
+        assert_eq!(0, success(()));
+    }
+
+    #[test]
+    fn clap_or_error_is_error() {
+        assert_eq!(1, clap_or_error(anyhow!("test")));
+    }
+
+    #[test]
+    fn clap_or_error_is_help() {
+        let mut cmd = Command::new(env!("CARGO_PKG_NAME"));
+        let error = cmd.error(DisplayHelp, "help");
+        let clap_error = Error::new(error);
+        assert_eq!(0, clap_or_error(clap_error));
+    }
+
+    #[test]
+    fn clap_or_error_is_version() {
+        let mut cmd = Command::new(env!("CARGO_PKG_NAME"));
+        let error = cmd.error(DisplayVersion, "1.0");
+        let clap_error = Error::new(error);
+        assert_eq!(0, clap_or_error(clap_error));
+    }
+
+    #[test]
+    fn clap_or_error_is_other_clap_error() {
+        let mut cmd = Command::new(env!("CARGO_PKG_NAME"));
+        let error = cmd.error(ErrorKind::InvalidValue, "Some failure case");
+        let clap_error = Error::new(error);
+        assert_eq!(1, clap_or_error(clap_error));
+    }
+}

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -30,6 +30,8 @@ pub(crate) enum Error {
     CheckKeyNotFound,
     #[error("Error generating shares")]
     ShareGeneration,
+    #[error("Store not unlocked")]
+    StoreNotUnlocked,
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -7,7 +7,6 @@
 // modified, or distributed except according to those terms.
 
 use clap::error::ErrorKind;
-use tracing::error;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -21,18 +21,22 @@ pub(crate) enum Error {
     ConfigLoad,
     #[error("Unable to initialize tracing")]
     TracingInit,
+    #[error("Unable to initialize the database")]
+    DatabaseInit,
+    #[error("Unable to generate a nonce key")]
+    NonceKeyGen,
 }
 
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn clap_or_error(err: anyhow::Error) -> i32 {
     let disp_err = || {
-        eprint!("{err:?}");
+        error!("{err:?}");
         1
     };
     match err.downcast_ref::<clap::Error>() {
         Some(e) => match e.kind() {
             ErrorKind::DisplayHelp => {
-                eprint!("{e}");
+                error!("{e}");
                 0
             }
             ErrorKind::DisplayVersion => 0,

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -37,13 +37,13 @@ pub(crate) enum Error {
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn clap_or_error(err: anyhow::Error) -> i32 {
     let disp_err = || {
-        error!("{err:?}");
+        eprintln!("{err:?}");
         1
     };
     match err.downcast_ref::<clap::Error>() {
         Some(e) => match e.kind() {
             ErrorKind::DisplayHelp => {
-                error!("{e}");
+                eprintln!("{e}");
                 0
             }
             ErrorKind::DisplayVersion => 0,
@@ -63,7 +63,7 @@ pub(crate) fn clap_or_error(err: anyhow::Error) -> i32 {
             | ErrorKind::Io
             | ErrorKind::Format => disp_err(),
             _ => {
-                error!("Unknown ErrorKind");
+                eprintln!("Unknown ErrorKind");
                 disp_err()
             }
         },

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -32,6 +32,10 @@ pub(crate) enum Error {
     ShareGeneration,
     #[error("Store not unlocked")]
     StoreNotUnlocked,
+    #[error("Invalid regex")]
+    InvalidRegex,
+    #[error("Unable to read next item from table iterator")]
+    TableIterRead,
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/salusd/src/error.rs
+++ b/salusd/src/error.rs
@@ -25,6 +25,11 @@ pub(crate) enum Error {
     DatabaseInit,
     #[error("Unable to generate a nonce key")]
     NonceKeyGen,
+    #[allow(dead_code)]
+    #[error("Could not find CHECK_KEY in database")]
+    CheckKeyNotFound,
+    #[error("Error generating shares")]
+    ShareGeneration,
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/salusd/src/handler/mod.rs
+++ b/salusd/src/handler/mod.rs
@@ -54,7 +54,7 @@ where
             Action::Store(store) => self.store(store).await?,
             Action::Read(key) => self.read(key).await?,
             Action::GetThreshold => self.get_threshold().await?,
-            Action::FindKey(_key) => self.error(Error::msg("FindKey not implemented")).await?,
+            Action::FindKey(key) => self.find(key).await?,
         }
         Ok(())
     }
@@ -167,6 +167,10 @@ where
             }
         }
         Ok(())
+    }
+
+    async fn find(&mut self, _regex: String) -> Result<()> {
+        self.error(Error::msg("Find not implemented")).await
     }
 
     async fn response(&mut self, message: Response) -> Result<()> {

--- a/salusd/src/handler/mod.rs
+++ b/salusd/src/handler/mod.rs
@@ -169,8 +169,16 @@ where
         Ok(())
     }
 
-    async fn find(&mut self, _regex: String) -> Result<()> {
-        self.error(Error::msg("Find not implemented")).await
+    async fn find(&mut self, regex: String) -> Result<()> {
+        match self.unlock_store(|store| -> Result<Response> { store.find(&regex) }) {
+            Ok(response) => {
+                self.response(response).await?;
+            }
+            Err(e) => {
+                self.error(e).await?;
+            }
+        }
+        Ok(())
     }
 
     async fn response(&mut self, message: Response) -> Result<()> {

--- a/salusd/src/handler/mod.rs
+++ b/salusd/src/handler/mod.rs
@@ -54,6 +54,7 @@ where
             Action::Store(store) => self.store(store).await?,
             Action::Read(key) => self.read(key).await?,
             Action::GetThreshold => self.get_threshold().await?,
+            Action::FindKey(_key) => self.error(Error::msg("FindKey not implemented")).await?,
         }
         Ok(())
     }

--- a/salusd/src/handler/mod.rs
+++ b/salusd/src/handler/mod.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use anyhow::Result;
+use bincode::{config::standard, encode_to_vec};
+use interprocess::local_socket::traits::tokio::SendHalf;
+use libsalus::{Action, Response, Shares, SsssConfig, gen_key};
+use tokio::{io::AsyncWriteExt, sync::mpsc::UnboundedSender};
+use tracing::{error, trace, warn};
+
+pub(crate) enum ShareStoreMessage {
+    AddShare(String),
+    Unlock,
+    ClearKey,
+}
+
+#[derive(Default)]
+pub(crate) struct ShareStore {
+    shares: Vec<String>,
+    key: Vec<u8>,
+}
+
+impl ShareStore {
+    pub(crate) fn clear_shares(&mut self) {
+        self.shares.clear();
+    }
+
+    pub(crate) fn clear_key(&mut self) {
+        self.key.clear();
+    }
+
+    pub(crate) fn add_key(&mut self, key: Vec<u8>) {
+        self.key = key;
+    }
+
+    pub(crate) fn add_share(&mut self, share: String) {
+        self.shares.push(share);
+    }
+
+    pub(crate) fn share_count(&self) -> usize {
+        self.shares.len()
+    }
+
+    pub(crate) fn shares(&self) -> Vec<String> {
+        self.shares.clone()
+    }
+}
+
+pub(crate) async fn handler<T: SendHalf + Unpin>(
+    sender: &mut T,
+    message: Action,
+    stx: UnboundedSender<ShareStoreMessage>,
+) -> Result<()> {
+    trace!("Got a message from a client: {message:?}");
+    match message {
+        Action::Genkey => {
+            if let Ok(shares) = gen_key(&SsssConfig::default()) {
+                let shares_msg = Response::Shares(Shares::builder().shares(shares).build());
+                response(sender, shares_msg).await?;
+            } else {
+                error!("Error generating shares");
+                error(sender).await?;
+            }
+        }
+        Action::Share(share) => {
+            trace!("Share received");
+            stx.send(ShareStoreMessage::AddShare(share.share().to_string()))?;
+            success(sender).await?;
+        }
+        Action::Unlock => {
+            stx.send(ShareStoreMessage::Unlock)?;
+            success(sender).await?;
+        }
+        Action::Init(_init) => {
+            warn!("Initialize requested, but not implemented.");
+            success(sender).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn response<T: SendHalf + Unpin>(sender: &mut T, message: Response) -> Result<()> {
+    let message = encode_to_vec(message, standard())?;
+    sender.write_all(&message).await?;
+    sender.flush().await?;
+    Ok(())
+}
+
+async fn success<T: SendHalf + Unpin>(sender: &mut T) -> Result<()> {
+    response(sender, Response::Success).await
+}
+
+async fn error<T: SendHalf + Unpin>(sender: &mut T) -> Result<()> {
+    response(sender, Response::Error).await
+}

--- a/salusd/src/handler/mod.rs
+++ b/salusd/src/handler/mod.rs
@@ -52,7 +52,7 @@ where
             Action::Share(share) => self.add_share(share.share()).await?,
             Action::Unlock => self.unlock().await?,
             Action::Store(store) => self.store(store).await?,
-            Action::Read(_key) => {}
+            Action::Read(key) => self.read(key).await?,
             Action::GetThreshold => self.get_threshold().await?,
         }
         Ok(())
@@ -146,6 +146,18 @@ where
         match self.unlock_store(|store| -> Result<Response> {
             store.store(&key, value.as_bytes().to_vec())
         }) {
+            Ok(response) => {
+                self.response(response).await?;
+            }
+            Err(e) => {
+                self.error(e).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn read(&mut self, key: String) -> Result<()> {
+        match self.unlock_store(|store| -> Result<Response> { store.read(&key) }) {
             Ok(response) => {
                 self.response(response).await?;
             }

--- a/salusd/src/logging/mod.rs
+++ b/salusd/src/logging/mod.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::{fs::File, path::PathBuf};
+
+use anyhow::Result;
+use tracing::{Level, level_filters::LevelFilter};
+use tracing_subscriber::{EnvFilter, Layer, Registry, fmt::time::UtcTime};
+use tracing_subscriber_init::{Iso8601, TracingConfig, compact, try_init};
+
+use crate::{
+    config::{ConfigSalusd, PathDefaults},
+    utils::to_path_buf,
+};
+
+/// Initialize tracing
+pub(crate) fn initialize<T, U>(
+    tracing_config: &T,
+    config: &ConfigSalusd,
+    defaults: &U,
+    layers_opt: Option<Vec<Box<dyn Layer<Registry> + Send + Sync>>>,
+) -> Result<()>
+where
+    T: TracingConfig,
+    U: PathDefaults,
+{
+    let mut layers = layers_opt.unwrap_or_default();
+
+    // Setup the stdout tracing layer if enabled
+    if config.enable_std_output() {
+        let (layer, level_filter) = compact(tracing_config);
+        let directives = directives(config, level_filter);
+        let filter = EnvFilter::builder()
+            .with_default_directive(level_filter.into())
+            .parse_lossy(directives);
+        let stdout_layer = layer
+            .with_timer(UtcTime::new(Iso8601::DEFAULT))
+            .with_filter(filter);
+        layers.push(stdout_layer.boxed());
+    }
+
+    // Setup the tracing file layer
+    let tracing_absolute_path = tracing_absolute_path(defaults)?;
+    let tracing_file = File::create(&tracing_absolute_path)?;
+    let (layer, level_filter) = compact(tracing_config);
+    let directives = directives(config, level_filter);
+    let filter = EnvFilter::builder()
+        .with_default_directive(level_filter.into())
+        .parse_lossy(directives);
+    let file_layer = layer
+        .with_timer(UtcTime::new(Iso8601::DEFAULT))
+        .with_writer(tracing_file)
+        .with_filter(filter);
+    layers.push(file_layer.boxed());
+
+    try_init(layers)?;
+    Ok(())
+}
+
+fn directives(config: &ConfigSalusd, level_filter: LevelFilter) -> String {
+    let directives_base = match level_filter.into_level() {
+        Some(level) => match level {
+            Level::TRACE => "trace",
+            Level::DEBUG => "debug",
+            Level::INFO => "info",
+            Level::WARN => "warn",
+            Level::ERROR => "error",
+        },
+        None => "info",
+    };
+
+    if let Some(directives) = config.tracing().directives() {
+        format!("{directives_base},{directives}")
+    } else {
+        directives_base.to_string()
+    }
+}
+
+fn tracing_absolute_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let default_fn = || -> Result<PathBuf> { default_tracing_absolute_path(defaults) };
+    defaults
+        .tracing_absolute_path()
+        .as_ref()
+        .map_or_else(default_fn, to_path_buf)
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn default_tracing_absolute_path<D>(defaults: &D) -> Result<PathBuf>
+where
+    D: PathDefaults,
+{
+    let mut config_file_path = PathBuf::from(defaults.default_tracing_path());
+    config_file_path.push(defaults.default_tracing_file_name());
+    let _ = config_file_path.set_extension("log");
+    Ok(config_file_path)
+}

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -124,7 +124,7 @@
         refining_impl_trait_internal,
         refining_impl_trait_reachable,
         renamed_and_removed_lints,
-        repr_transparent_external_private_fields,
+        repr_transparent_non_zst_fields,
         rust_2021_incompatible_closure_captures,
         rust_2021_incompatible_or_patterns,
         rust_2021_prefixes_incompatible_syntax,

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -6,128 +6,261 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::io::ErrorKind;
+//! salus daemon
+
+// rustc lints
+#![cfg_attr(
+    all(feature = "unstable", nightly),
+    feature(
+        multiple_supertrait_upcastable,
+        must_not_suspend,
+        non_exhaustive_omitted_patterns_lint,
+        rustdoc_missing_doc_code_examples,
+        strict_provenance_lints,
+        supertrait_item_shadowing,
+        unqualified_local_imports,
+    )
+)]
+#![cfg_attr(nightly, allow(single_use_lifetimes))]
+#![cfg_attr(
+    nightly,
+    deny(
+        absolute_paths_not_starting_with_crate,
+        ambiguous_glob_imports,
+        ambiguous_glob_reexports,
+        ambiguous_negative_literals,
+        ambiguous_wide_pointer_comparisons,
+        anonymous_parameters,
+        array_into_iter,
+        asm_sub_register,
+        async_fn_in_trait,
+        bad_asm_style,
+        bare_trait_objects,
+        boxed_slice_into_iter,
+        break_with_label_and_loop,
+        clashing_extern_declarations,
+        closure_returning_async_block,
+        coherence_leak_check,
+        confusable_idents,
+        const_evaluatable_unchecked,
+        const_item_mutation,
+        dangling_pointers_from_temporaries,
+        dead_code,
+        dependency_on_unit_never_type_fallback,
+        deprecated,
+        deprecated_in_future,
+        deprecated_safe_2024,
+        deprecated_where_clause_location,
+        deref_into_dyn_supertrait,
+        deref_nullptr,
+        double_negations,
+        drop_bounds,
+        dropping_copy_types,
+        dropping_references,
+        duplicate_macro_attributes,
+        dyn_drop,
+        edition_2024_expr_fragment_specifier,
+        elided_lifetimes_in_paths,
+        ellipsis_inclusive_range_patterns,
+        explicit_outlives_requirements,
+        exported_private_dependencies,
+        ffi_unwind_calls,
+        forbidden_lint_groups,
+        forgetting_copy_types,
+        forgetting_references,
+        for_loops_over_fallibles,
+        function_item_references,
+        hidden_glob_reexports,
+        if_let_rescope,
+        impl_trait_overcaptures,
+        impl_trait_redundant_captures,
+        improper_ctypes,
+        improper_ctypes_definitions,
+        inline_no_sanitize,
+        internal_features,
+        invalid_from_utf8,
+        invalid_macro_export_arguments,
+        invalid_nan_comparisons,
+        invalid_value,
+        irrefutable_let_patterns,
+        keyword_idents_2018,
+        keyword_idents_2024,
+        large_assignments,
+        late_bound_lifetime_arguments,
+        legacy_derive_helpers,
+        let_underscore_drop,
+        macro_use_extern_crate,
+        map_unit_fn,
+        meta_variable_misuse,
+        mismatched_lifetime_syntaxes,
+        missing_abi,
+        missing_copy_implementations,
+        missing_debug_implementations,
+        missing_docs,
+        missing_unsafe_on_extern,
+        mixed_script_confusables,
+        named_arguments_used_positionally,
+        never_type_fallback_flowing_into_unsafe,
+        no_mangle_generic_items,
+        non_ascii_idents,
+        non_camel_case_types,
+        non_contiguous_range_endpoints,
+        non_fmt_panics,
+        non_local_definitions,
+        non_shorthand_field_patterns,
+        non_snake_case,
+        non_upper_case_globals,
+        noop_method_call,
+        opaque_hidden_inferred_bound,
+        out_of_scope_macro_calls,
+        overlapping_range_endpoints,
+        path_statements,
+        private_bounds,
+        private_interfaces,
+        ptr_to_integer_transmute_in_consts,
+        redundant_imports,
+        redundant_lifetimes,
+        redundant_semicolons,
+        refining_impl_trait_internal,
+        refining_impl_trait_reachable,
+        renamed_and_removed_lints,
+        repr_transparent_external_private_fields,
+        rust_2021_incompatible_closure_captures,
+        rust_2021_incompatible_or_patterns,
+        rust_2021_prefixes_incompatible_syntax,
+        rust_2021_prelude_collisions,
+        rust_2024_guarded_string_incompatible_syntax,
+        rust_2024_incompatible_pat,
+        rust_2024_prelude_collisions,
+        self_constructor_from_outer_item,
+        semicolon_in_expressions_from_macros,
+        single_use_lifetimes,
+        special_module_name,
+        stable_features,
+        static_mut_refs,
+        suspicious_double_ref_op,
+        tail_expr_drop_order,
+        trivial_bounds,
+        trivial_casts,
+        trivial_numeric_casts,
+        type_alias_bounds,
+        tyvar_behind_raw_pointer,
+        uncommon_codepoints,
+        unconditional_recursion,
+        uncovered_param_in_projection,
+        unexpected_cfgs,
+        unfulfilled_lint_expectations,
+        ungated_async_fn_track_caller,
+        uninhabited_static,
+        unit_bindings,
+        unknown_lints,
+        unknown_or_malformed_diagnostic_attributes,
+        unnameable_test_items,
+        unnameable_types,
+        unpredictable_function_pointer_comparisons,
+        unreachable_code,
+        unreachable_patterns,
+        unreachable_pub,
+        unsafe_attr_outside_unsafe,
+        unsafe_code,
+        unsafe_op_in_unsafe_fn,
+        unstable_name_collisions,
+        unstable_syntax_pre_expansion,
+        unused_allocation,
+        unused_assignments,
+        unused_associated_type_bounds,
+        unused_attributes,
+        unused_braces,
+        unused_comparisons,
+        unused_crate_dependencies,
+        unused_doc_comments,
+        unused_extern_crates,
+        unused_features,
+        unused_import_braces,
+        unused_imports,
+        unused_labels,
+        unused_lifetimes,
+        unused_macro_rules,
+        unused_macros,
+        unused_must_use,
+        unused_mut,
+        unused_parens,
+        unused_qualifications,
+        unused_results,
+        unused_unsafe,
+        unused_variables,
+        useless_ptr_null_checks,
+        uses_power_alignment,
+        variant_size_differences,
+        while_true,
+    )
+)]
+// If nightly and unstable, allow `incomplete_features` and `unstable_features`
+#![cfg_attr(
+    all(feature = "unstable", nightly),
+    allow(incomplete_features, unstable_features)
+)]
+// If nightly and not unstable, deny `incomplete_features` and `unstable_features`
+#![cfg_attr(
+    all(not(feature = "unstable"), nightly),
+    deny(incomplete_features, unstable_features)
+)]
+// The unstable lints
+#![cfg_attr(
+    all(feature = "unstable", nightly),
+    deny(
+        fuzzy_provenance_casts,
+        lossy_provenance_casts,
+        multiple_supertrait_upcastable,
+        must_not_suspend,
+        non_exhaustive_omitted_patterns,
+        supertrait_item_shadowing_definition,
+        supertrait_item_shadowing_usage,
+        unqualified_local_imports,
+    )
+)]
+// clippy lints
+#![cfg_attr(nightly, deny(clippy::all, clippy::pedantic))]
+#![allow(clippy::ref_option)]
+// rustdoc lints
+#![cfg_attr(
+    nightly,
+    deny(
+        rustdoc::bare_urls,
+        rustdoc::broken_intra_doc_links,
+        rustdoc::invalid_codeblock_attributes,
+        rustdoc::invalid_html_tags,
+        rustdoc::missing_crate_level_docs,
+        rustdoc::private_doc_tests,
+        rustdoc::private_intra_doc_links,
+    )
+)]
+#![cfg_attr(
+    all(nightly, feature = "unstable"),
+    deny(rustdoc::missing_doc_code_examples)
+)]
+#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+#![cfg_attr(all(docsrs, nightly), feature(doc_cfg))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+use std::process;
 
 use anyhow::Result;
-use bincode::{config::standard, decode_from_slice, encode_to_vec};
-use interprocess::local_socket::{
-    GenericFilePath, GenericNamespaced, ListenerOptions, NameType, ToFsName, ToNsName,
-    traits::tokio::{Listener, RecvHalf, Stream as _},
-};
-use libsalus::Message;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::mpsc,
-};
+
+use crate::error::{clap_or_error, success};
+
+mod config;
+mod error;
+mod handler;
+mod logging;
+mod runtime;
+mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Pick a name.
-    let base_socket = "salus.sock";
-    let ns_prefix = "/var/run/";
-    let name = if GenericNamespaced::is_supported() {
-        format!("{ns_prefix}{base_socket}").to_ns_name::<GenericNamespaced>()?
-    } else {
-        format!("/tmp/{base_socket}").to_fs_name::<GenericFilePath>()?
-    };
-
-    eprintln!("Name chosen: {name:?}");
-    // Configure our listener...
-    let opts = ListenerOptions::new().name(name);
-
-    // ...and create it.
-    let listener = match opts.create_tokio() {
-        Err(e) if e.kind() == ErrorKind::AddrInUse => {
-            // When a program that uses a file-type socket name terminates its socket server
-            // without deleting the file, a "corpse socket" remains, which can neither be
-            // connected to nor reused by a new listener. Normally, Interprocess takes care of
-            // this on affected platforms by deleting the socket file when the listener is
-            // dropped. (This is vulnerable to all sorts of races and thus can be disabled.)
-            //
-            // There are multiple ways this error can be handled, if it occurs, but when the
-            // listener only comes from Interprocess, it can be assumed that its previous instance
-            // either has crashed or simply hasn't exited yet. In this example, we leave cleanup
-            // up to the user, but in a real application, you usually don't want to do that.
-            eprintln!(
-                "Error: could not start server because the socket file is occupied. Please check
-                if {base_socket} is in use by another process and try again."
-            );
-            return Err(e.into());
-        }
-        x => x?,
-    };
-
-    // The syncronization between the server and client, if any is used, goes here.
-    eprintln!("Server running at {base_socket:?}");
-
-    // Set up our loop boilerplate that processes our incoming connections.
-    loop {
-        // Sort out situations when establishing an incoming connection caused an error.
-        let conn = match listener.accept().await {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("There was an error with an incoming connection: {e}");
-                continue;
-            }
-        };
-
-        let (mut receiver, mut sender) = conn.split();
-        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
-
-        let _client_recv_handle = tokio::spawn(async move {
-            while let Some(message) = rx.recv().await {
-                eprintln!("Got a message from a client: {message:?}");
-                match message {
-                    Message::Share(share) => {
-                        eprintln!("Share received: {}", share.share());
-                    }
-                    Message::Unlock => {
-                        eprintln!("Unlock requested, but not implemented.");
-                    }
-                    _ => {}
-                }
-                let mut blah = async || -> Result<()> {
-                    let message = encode_to_vec(Message::Success, standard())?;
-                    sender.write_all(&message).await?;
-                    sender.flush().await?;
-                    Ok(())
-                };
-                if let Err(e) = blah().await {
-                    eprintln!("There was an error when sending: {e}");
-                }
-            }
-        });
-
-        // Spawn new parallel asynchronous tasks onto the Tokio runtime and hand the connection
-        // over to them so that multiple clients could be processed simultaneously in a
-        // lightweight fashion.
-        tokio::spawn(async move {
-            // The outer match processes errors that happen when we're connecting to something.
-            // The inner if-let processes errors that happen during the connection.
-            eprintln!("Got a connection!");
-            if let Err(e) = handle_conn(&mut receiver, tx).await {
-                eprintln!("Error while handling connection: {e}");
-            }
-            eprintln!("Connection closed.");
-        });
-    }
-}
-
-// Describe the things we do when we've got a connection ready.
-async fn handle_conn<T: RecvHalf + Unpin>(
-    receiver: &mut T,
-    txc: mpsc::UnboundedSender<Message>,
-) -> Result<()> {
-    // Describe the receive operation as receiving a line into our big buffer.
-    let mut msg_buf = Vec::new();
-    let _msg_size = receiver.read_to_end(&mut msg_buf).await?;
-
-    let decoded_res: Result<(Message, usize)> =
-        decode_from_slice(&msg_buf, standard()).map_err(Into::into);
-    if let Ok((message, _)) = decoded_res {
-        println!("Client sent: {:?}", message);
-        txc.send(message)?;
-    }
-
-    Ok(())
+    process::exit(
+        runtime::run::<Vec<&str>, &str>(None)
+            .await
+            .map_or_else(clap_or_error, success),
+    )
 }

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -255,6 +255,7 @@ mod error;
 mod handler;
 mod logging;
 mod runtime;
+mod store;
 mod utils;
 
 #[tokio::main]

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<()> {
         format!("/tmp/{base_socket}").to_fs_name::<GenericFilePath>()?
     };
 
+    eprintln!("Name chosen: {name:?}");
     // Configure our listener...
     let opts = ListenerOptions::new().name(name);
 
@@ -57,7 +58,7 @@ async fn main() -> Result<()> {
     };
 
     // The syncronization between the server and client, if any is used, goes here.
-    eprintln!("Server running at {base_socket}");
+    eprintln!("Server running at {base_socket:?}");
 
     // Set up our loop boilerplate that processes our incoming connections.
     loop {

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -250,6 +250,7 @@ use anyhow::Result;
 use crate::error::{clap_or_error, success};
 
 mod config;
+mod db;
 mod error;
 mod handler;
 mod logging;

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -26,9 +26,9 @@ async fn main() -> Result<()> {
     let base_socket = "salus.sock";
     let ns_prefix = "/var/run/";
     let name = if GenericNamespaced::is_supported() {
-        format!("{}{}", ns_prefix, base_socket).to_ns_name::<GenericNamespaced>()?
+        format!("{ns_prefix}{base_socket}").to_ns_name::<GenericNamespaced>()?
     } else {
-        format!("/tmp/{}", base_socket).to_fs_name::<GenericFilePath>()?
+        format!("/tmp/{base_socket}").to_fs_name::<GenericFilePath>()?
     };
 
     // Configure our listener...

--- a/salusd/src/main.rs
+++ b/salusd/src/main.rs
@@ -221,7 +221,6 @@
 )]
 // clippy lints
 #![cfg_attr(nightly, deny(clippy::all, clippy::pedantic))]
-#![allow(clippy::ref_option)]
 // rustdoc lints
 #![cfg_attr(
     nightly,
@@ -239,9 +238,7 @@
     all(nightly, feature = "unstable"),
     deny(rustdoc::missing_doc_code_examples)
 )]
-#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(all(docsrs, nightly), feature(doc_cfg))]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use std::process;
 

--- a/salusd/src/runtime/cli.rs
+++ b/salusd/src/runtime/cli.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use clap::{ArgAction, Parser};
+use config::{ConfigError, Map, Source, Value, ValueKind};
+use getset::Getters;
+
+use crate::config::PathDefaults;
+
+#[derive(Clone, Debug, Getters, Parser)]
+#[command(author, version, about, long_about = None)]
+#[getset(get = "pub(crate)")]
+pub(crate) struct Cli {
+    /// Set logging verbosity.  More v's, more verbose.
+    #[clap(
+        short,
+        long,
+        action = ArgAction::Count,
+        help = "Turn up logging verbosity (multiple will turn it up more)",
+        conflicts_with = "quiet",
+    )]
+    verbose: u8,
+    /// Set logging quietness.  More q's, more quiet.
+    #[clap(
+        short,
+        long,
+        action = ArgAction::Count,
+        help = "Turn down logging verbosity (multiple will turn it down more)",
+        conflicts_with = "verbose",
+    )]
+    quiet: u8,
+    /// Enable logging to stdout/stderr in additions to the tracing output file
+    /// * NOTE * - This should not be used when running as a daemon/service
+    #[clap(short, long, help = "Enable logging to stdout/stderr")]
+    enable_std_output: bool,
+    /// The absolute path to a non-standard config file
+    #[clap(short, long, help = "Specify the absolute path to the config file")]
+    config_absolute_path: Option<String>,
+    /// The absolute path to a non-standard tracing output file
+    #[clap(
+        short,
+        long,
+        help = "Specify the absolute path to the tracing output file"
+    )]
+    tracing_absolute_path: Option<String>,
+}
+
+impl Source for Cli {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new((*self).clone())
+    }
+
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        let mut map = Map::new();
+        let origin = String::from("command line");
+        let _old = map.insert(
+            "verbose".to_string(),
+            Value::new(Some(&origin), ValueKind::U64(u8::into(self.verbose))),
+        );
+        let _old = map.insert(
+            "quiet".to_string(),
+            Value::new(Some(&origin), ValueKind::U64(u8::into(self.quiet))),
+        );
+        let _old = map.insert(
+            "enable_std_output".to_string(),
+            Value::new(Some(&origin), ValueKind::Boolean(self.enable_std_output)),
+        );
+        if let Some(config_path) = &self.config_absolute_path {
+            let _old = map.insert(
+                "config_path".to_string(),
+                Value::new(Some(&origin), ValueKind::String(config_path.clone())),
+            );
+        }
+        if let Some(tracing_path) = &self.tracing_absolute_path {
+            let _old = map.insert(
+                "tracing_path".to_string(),
+                Value::new(Some(&origin), ValueKind::String(tracing_path.clone())),
+            );
+        }
+        Ok(map)
+    }
+}
+
+impl PathDefaults for Cli {
+    fn env_prefix(&self) -> String {
+        env!("CARGO_PKG_NAME").to_ascii_uppercase()
+    }
+
+    fn config_absolute_path(&self) -> Option<String> {
+        self.config_absolute_path.clone()
+    }
+
+    fn default_file_path(&self) -> String {
+        format!("/var/lib/{}", env!("CARGO_PKG_NAME"))
+    }
+
+    fn default_file_name(&self) -> String {
+        env!("CARGO_PKG_NAME").to_string()
+    }
+
+    fn tracing_absolute_path(&self) -> Option<String> {
+        self.tracing_absolute_path.clone()
+    }
+
+    fn default_tracing_path(&self) -> String {
+        format!("/var/log/{}", env!("CARGO_PKG_NAME"))
+    }
+
+    fn default_tracing_file_name(&self) -> String {
+        env!("CARGO_PKG_NAME").to_string()
+    }
+}

--- a/salusd/src/runtime/cli.rs
+++ b/salusd/src/runtime/cli.rs
@@ -48,6 +48,9 @@ pub(crate) struct Cli {
         help = "Specify the absolute path to the tracing output file"
     )]
     tracing_absolute_path: Option<String>,
+    /// The absolute path to a non-standard database file
+    #[clap(short, long, help = "Specify the absolute path to the database file")]
+    database_absolute_path: Option<String>,
 }
 
 impl Source for Cli {
@@ -82,6 +85,12 @@ impl Source for Cli {
                 Value::new(Some(&origin), ValueKind::String(tracing_path.clone())),
             );
         }
+        if let Some(database_path) = &self.database_absolute_path {
+            let _old = map.insert(
+                "database_path".to_string(),
+                Value::new(Some(&origin), ValueKind::String(database_path.clone())),
+            );
+        }
         Ok(map)
     }
 }
@@ -112,6 +121,18 @@ impl PathDefaults for Cli {
     }
 
     fn default_tracing_file_name(&self) -> String {
+        env!("CARGO_PKG_NAME").to_string()
+    }
+
+    fn database_absolute_path(&self) -> Option<String> {
+        self.database_absolute_path.clone()
+    }
+
+    fn default_database_path(&self) -> String {
+        format!("/var/lib/{}", env!("CARGO_PKG_NAME"))
+    }
+
+    fn default_database_file_name(&self) -> String {
         env!("CARGO_PKG_NAME").to_string()
     }
 }

--- a/salusd/src/runtime/mod.rs
+++ b/salusd/src/runtime/mod.rs
@@ -113,10 +113,12 @@ where
         let (mut receiver, sender) = conn.split();
         let (tx, mut rx) = unbounded_channel::<Action>();
         let share_store_c = share_store.clone();
+        let kt = config.key_timeout();
         let _client_recv_handle = spawn(async move {
             let mut action_handler = ActionHandler::builder()
                 .sender(sender)
                 .store(share_store_c)
+                .key_timeout(kt)
                 .build();
             while let Some(message) = rx.recv().await {
                 if let Err(e) = action_handler.action_handler(message).await {

--- a/salusd/src/runtime/mod.rs
+++ b/salusd/src/runtime/mod.rs
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::{
+    ffi::OsString,
+    io::ErrorKind,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::{Context, Result};
+use bincode::{config::standard, decode_from_slice};
+use clap::Parser;
+use interprocess::local_socket::{
+    ListenerOptions,
+    traits::tokio::{Listener, RecvHalf, Stream as _},
+};
+use libsalus::{Action, socket_name, unlock_key};
+use tokio::{
+    io::AsyncReadExt,
+    spawn,
+    sync::mpsc::{UnboundedSender, unbounded_channel},
+    time::{Duration, sleep},
+};
+use tracing::{error, info, trace, warn};
+
+use crate::{
+    config::{ConfigSalusd, load},
+    error::Error,
+    handler::{ShareStore, ShareStoreMessage, handler},
+    logging::initialize,
+    runtime::cli::Cli,
+};
+
+mod cli;
+
+pub(crate) async fn run<I, T>(args: Option<I>) -> Result<()>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    // Parse the command line
+    let cli = if let Some(args) = args {
+        Cli::try_parse_from(args)?
+    } else {
+        Cli::try_parse()?
+    };
+
+    // Load the configuration
+    let config = load::<Cli, ConfigSalusd, Cli>(&cli, &cli).with_context(|| Error::ConfigLoad)?;
+
+    // Initialize tracing
+    initialize(&config, &config, &cli, None).with_context(|| Error::TracingInit)?;
+
+    trace!("configuration loaded");
+    trace!("tracing initialized");
+
+    // Pick a name.
+    let (_base_name, name) = socket_name()?;
+
+    trace!("Socket setup");
+
+    // Configure our listener...
+    let opts = ListenerOptions::new().name(name);
+
+    // ...and create it.
+    let listener = match opts.create_tokio() {
+        Err(e) if e.kind() == ErrorKind::AddrInUse => {
+            // When a program that uses a file-type socket name terminates its socket server
+            // without deleting the file, a "corpse socket" remains, which can neither be
+            // connected to nor reused by a new listener. Normally, Interprocess takes care of
+            // this on affected platforms by deleting the socket file when the listener is
+            // dropped. (This is vulnerable to all sorts of races and thus can be disabled.)
+            //
+            // There are multiple ways this error can be handled, if it occurs, but when the
+            // listener only comes from Interprocess, it can be assumed that its previous instance
+            // either has crashed or simply hasn't exited yet. In this example, we leave cleanup
+            // up to the user, but in a real application, you usually don't want to do that.
+            error!(
+                "Error: could not start server because the socket file is occupied. Please check
+                if the socket is in use by another process and try again."
+            );
+            return Err(e.into());
+        }
+        x => x?,
+    };
+
+    // The syncronization between the server and client, if any is used, goes here.
+    info!("salusd daemon is running");
+
+    let share_store = Arc::new(Mutex::new(ShareStore::default()));
+
+    let (stx, mut srx) = unbounded_channel::<ShareStoreMessage>();
+
+    let stx_c = stx.clone();
+    let _blah = spawn(async move {
+        while let Some(ssm) = srx.recv().await {
+            match ssm {
+                ShareStoreMessage::AddShare(share) => {
+                    unlock_store(&share_store, |store: &mut ShareStore| {
+                        store.add_share(share.clone());
+                        info!(
+                            "Added a share to the store. Total shares: {}",
+                            store.share_count()
+                        );
+                    });
+                }
+                ShareStoreMessage::Unlock => {
+                    unlock_store(&share_store, |store: &mut ShareStore| {
+                        if let Ok(key) = unlock_key(&store.shares()) {
+                            info!("Possible key bytes generated");
+                            let interval = sleep(Duration::from_secs(20));
+                            let stx_c = stx_c.clone();
+                            let _blah = spawn(async move {
+                                interval.await;
+                                stx_c.send(ShareStoreMessage::ClearKey).unwrap();
+                            });
+                            store.add_key(key);
+                        } else {
+                            error!("Failed to unlock key with provided shares");
+                        }
+                        store.clear_shares();
+                    });
+                }
+                ShareStoreMessage::ClearKey => {
+                    unlock_store(&share_store, |store: &mut ShareStore| {
+                        warn!("Key cleared due to timeout.");
+                        store.clear_key();
+                    });
+                }
+            }
+        }
+    });
+
+    // Set up our loop boilerplate that processes our incoming connections.
+    loop {
+        // Sort out situations when establishing an incoming connection caused an error.
+        let conn = match listener.accept().await {
+            Ok(c) => c,
+            Err(e) => {
+                error!("There was an error with an incoming connection: {e}");
+                continue;
+            }
+        };
+
+        let (mut receiver, mut sender) = conn.split();
+        let (tx, mut rx) = unbounded_channel::<Action>();
+        let stx_c = stx.clone();
+
+        let _client_recv_handle = spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if let Err(e) = handler(&mut sender, message, stx_c.clone()).await {
+                    error!("Error handling client message: {e}");
+                }
+            }
+        });
+
+        // Spawn new parallel asynchronous tasks onto the Tokio runtime and hand the connection
+        // over to them so that multiple clients could be processed simultaneously in a
+        // lightweight fashion.
+        let _handle = spawn(async move {
+            // The outer match processes errors that happen when we're connecting to something.
+            // The inner if-let processes errors that happen during the connection.
+            trace!("Got a connection!");
+            if let Err(e) = handle_conn(&mut receiver, tx).await {
+                error!("Error while handling connection: {e}");
+            }
+            trace!("Connection closed.");
+        });
+    }
+}
+
+// Describe the things we do when we've got a connection ready.
+async fn handle_conn<T: RecvHalf + Unpin>(
+    receiver: &mut T,
+    txc: UnboundedSender<Action>,
+) -> Result<()> {
+    // Describe the receive operation as receiving a line into our big buffer.
+    let mut msg_buf = Vec::new();
+    let _msg_size = receiver.read_to_end(&mut msg_buf).await?;
+
+    let decoded_res: Result<(Action, usize)> =
+        decode_from_slice(&msg_buf, standard()).map_err(Into::into);
+    if let Ok((message, _)) = decoded_res {
+        trace!("Client sent: {message:?}");
+        txc.send(message)?;
+    }
+
+    Ok(())
+}
+
+fn unlock_store(store: &Arc<Mutex<ShareStore>>, store_fn: impl Fn(&mut ShareStore)) {
+    let mut share_store = match store.lock() {
+        Ok(share_store) => share_store,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    store_fn(&mut share_store);
+}

--- a/salusd/src/store/mod.rs
+++ b/salusd/src/store/mod.rs
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use aws_lc_rs::{
+    aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey},
+    rand,
+};
+use bon::Builder;
+use libsalus::{Init, Response, Shares, SsssConfig, gen_shares, unlock_key};
+use redb::Database;
+use tracing::{error, info, trace};
+
+use crate::{
+    db::{
+        CHECK_KEY_KEY, INITIALIZED_KEY, NUM_SHARES_KEY, SALUS_CONFIG_TABLE_DEF,
+        SALUS_VAL_TABLE_DEF, THRESHOLD_KEY, read_value, unlock_redb,
+        values::{config::ConfigVal, salus::SalusVal},
+        write_value,
+    },
+    error::Error,
+};
+
+#[derive(Builder)]
+pub(crate) struct ShareStore {
+    #[builder(default)]
+    shares: Vec<String>,
+    #[allow(dead_code)]
+    key: Option<Vec<u8>>,
+    redb: Arc<Mutex<Database>>,
+}
+
+impl ShareStore {
+    #[allow(dead_code)]
+    fn clear_shares(&mut self) {
+        self.shares.clear();
+    }
+
+    pub(crate) fn clear_key(&mut self) {
+        self.key = None;
+    }
+
+    pub(crate) fn add_share<S: Into<String>>(&mut self, share: S) {
+        self.shares.push(share.into());
+    }
+
+    pub(crate) fn initialize(&mut self, init: Init) -> Result<Response> {
+        trace!(
+            "Initializing share store with {} shares and threshold {}",
+            init.num_shares(),
+            init.threshold()
+        );
+        unlock_redb(&self.redb, |db| -> Result<()> {
+            write_value::<&str, ConfigVal>(
+                db,
+                SALUS_CONFIG_TABLE_DEF,
+                NUM_SHARES_KEY,
+                ConfigVal::from_value(init.num_shares())?,
+            )?;
+            write_value::<&str, ConfigVal>(
+                db,
+                SALUS_CONFIG_TABLE_DEF,
+                THRESHOLD_KEY,
+                ConfigVal::from_value(init.threshold())?,
+            )?;
+            Ok(())
+        })?;
+        Ok(Response::Success)
+    }
+
+    pub(crate) fn gen_shares(&mut self) -> Result<Response> {
+        trace!("Generating shares for share store");
+        let mut initialized = false;
+        unlock_redb(&self.redb, |db| -> Result<()> {
+            if let Ok(init_opt) =
+                read_value::<&str, ConfigVal>(db, SALUS_CONFIG_TABLE_DEF, INITIALIZED_KEY)
+                && let Some(init) = init_opt
+            {
+                initialized = init.value().to_value::<bool>()?;
+            }
+            Ok(())
+        })?;
+
+        if initialized {
+            Ok(Response::AlreadyInitialiazed)
+        } else {
+            let mut key = [0u8; 32];
+            rand::fill(&mut key)?;
+            let mut num_shares = 5;
+            let mut threshold = 3;
+
+            unlock_redb(&self.redb, |db| -> Result<()> {
+                if let Ok(num_shares_opt) =
+                    read_value::<&str, ConfigVal>(db, SALUS_CONFIG_TABLE_DEF, NUM_SHARES_KEY)
+                    && let Some(num_shares_ag) = num_shares_opt
+                {
+                    num_shares = num_shares_ag.value().to_value::<u8>()?;
+                }
+                if let Ok(threshold_opt) =
+                    read_value::<&str, ConfigVal>(db, SALUS_CONFIG_TABLE_DEF, THRESHOLD_KEY)
+                    && let Some(threshold_ag) = threshold_opt
+                {
+                    threshold = threshold_ag.value().to_value::<u8>()?;
+                }
+                Ok(())
+            })?;
+
+            trace!("Generating {num_shares} shares with threshold {threshold}");
+            match gen_shares(
+                &SsssConfig::builder()
+                    .num_shares(num_shares)
+                    .threshold(threshold)
+                    .build(),
+                &key,
+            ) {
+                Ok(shares) => {
+                    let rnkey = RandomizedNonceKey::new(&AES_256_GCM, &key)
+                        .with_context(|| Error::NonceKeyGen)?;
+                    let mut check_key = CHECK_KEY_KEY.as_bytes().to_vec();
+                    let nonce = rnkey.seal_in_place_append_tag(Aad::empty(), &mut check_key)?;
+                    unlock_redb(&self.redb, |db| -> Result<()> {
+                        let salus_val = SalusVal::builder()
+                            .nonce(*nonce.as_ref())
+                            .ciphertext(check_key.clone())
+                            .build();
+                        write_value::<String, SalusVal>(
+                            db,
+                            SALUS_VAL_TABLE_DEF,
+                            CHECK_KEY_KEY.to_string(),
+                            salus_val,
+                        )?;
+                        write_value::<&str, ConfigVal>(
+                            db,
+                            SALUS_CONFIG_TABLE_DEF,
+                            INITIALIZED_KEY,
+                            ConfigVal::from_value(true)?,
+                        )?;
+                        Ok(())
+                    })?;
+                    Ok(Response::Shares(Shares::builder().shares(shares).build()))
+                }
+                Err(_) => Err(Error::ShareGeneration.into()),
+            }
+        }
+    }
+
+    pub(crate) fn get_threshold(&self) -> u8 {
+        let mut threshold = 3;
+        if let Ok(()) = unlock_redb(&self.redb, |db| -> Result<()> {
+            if let Ok(threshold_opt) =
+                read_value::<&str, ConfigVal>(db, SALUS_CONFIG_TABLE_DEF, THRESHOLD_KEY)
+                && let Some(threshold_ag) = threshold_opt
+            {
+                threshold = threshold_ag.value().to_value::<u8>()?;
+            }
+            Ok(())
+        }) {}
+        threshold
+    }
+
+    pub(crate) fn unlock(&mut self) -> Result<Response> {
+        match unlock_key(&self.shares) {
+            Ok(key) => {
+                unlock_redb(&self.redb, |redb_c| -> Result<()> {
+                    match read_value::<String, SalusVal>(
+                        redb_c,
+                        SALUS_VAL_TABLE_DEF,
+                        "CHECK_KEY".to_string(),
+                    ) {
+                        Err(e) => {
+                            error!("Error reading CHECK_KEY from database: {e}");
+                            return Err(e);
+                        }
+                        Ok(None) => {
+                            error!("CHECK_KEY not found in database");
+                            return Err(Error::CheckKeyNotFound.into());
+                        }
+                        Ok(Some(svag)) => {
+                            let sv = svag.value();
+                            let nonce = Nonce::from(&sv.nonce());
+                            let rnkey = RandomizedNonceKey::new(&AES_256_GCM, &key)
+                                .with_context(|| Error::NonceKeyGen)
+                                .unwrap();
+                            let mut ciphertext = sv.ciphertext().clone();
+                            let plaintext_b = rnkey
+                                .open_in_place(nonce, Aad::empty(), &mut ciphertext)
+                                .with_context(|| Error::NonceKeyGen)
+                                .unwrap();
+                            let plaintext = String::from_utf8_lossy(plaintext_b).to_string();
+                            trace!("Unlocked key with shares, got plaintext: {plaintext}");
+                            if plaintext == "CHECK_KEY" {
+                                info!("Key successfully unlocked and verified.");
+                                self.key = Some(key.clone());
+                            } else {
+                                error!("Failed to unlock key with provided shares");
+                            }
+                        }
+                    }
+                    Ok(())
+                })?;
+            }
+            Err(e) => error!("Failed to unlock key with provided shares: {e}"),
+        }
+        self.clear_shares();
+        Ok(Response::Success)
+    }
+
+    //         ShareStoreMessage::Store(store_val) => {
+    //             let key_val = store_val.key();
+    //             let mut value = store_val.value().as_bytes().to_vec();
+
+    //             if let Some(key) = &self.key {
+    //                 let nonce_key = RandomizedNonceKey::new(&AES_256_GCM, key)
+    //                     .with_context(|| Error::NonceKeyGen)?;
+    //                 let nonce = nonce_key.seal_in_place_append_tag(Aad::empty(), &mut value)?;
+    //                 unlock_redb(&self.redb, |db| -> Result<()> {
+    //                     let salus_val = SalusVal::builder()
+    //                         .nonce(*nonce.as_ref())
+    //                         .ciphertext(value.clone())
+    //                         .build();
+    //                     match write_value::<String, SalusVal>(
+    //                         db,
+    //                         SALUS_VAL_TABLE_DEF,
+    //                         key_val.to_string(),
+    //                         salus_val,
+    //                     ) {
+    //                         Err(e) => {
+    //                             error!("Error writing value to database: {e}");
+    //                             return Err(e);
+    //                         }
+    //                         Ok(()) => {
+    //                             info!("Stored value under key: {key_val}");
+    //                         }
+    //                     }
+    //                     Ok(())
+    //                 })?;
+    //             } else {
+    //                 error!("No key available to store value");
+    //             }
+    //             Ok(Response::Success)
+    //         }
+}

--- a/salusd/src/utils.rs
+++ b/salusd/src/utils.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 salus developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn to_path_buf(path: &String) -> Result<PathBuf> {
+    Ok(PathBuf::from(path))
+}


### PR DESCRIPTION
- Updates various dependencies, including `aws-lc-rs` to `1.14.0`, `aws-lc-sys` to `0.31.0`, and `bindgen` to `0.72.1`, among others, to ensure compatibility and leverage the latest improvements.
- Removes unused or outdated dependencies like `lazy_static`, `lazycell`, `home`, and `which` to streamline the dependency tree.
- Refactors `Cargo.lock` to reflect the updated dependency versions and checksums.
- Addresses a potential issue on Windows by explicitly dropping the sender after use in a specific code pat